### PR TITLE
Check for PICK_BAD_INSTABLE stage in qsearch movepicker earlier

### DIFF
--- a/src/include/uci.h
+++ b/src/include/uci.h
@@ -26,7 +26,7 @@
 # include <time.h>
 # include "inlining.h"
 
-# define UCI_VERSION "v31.3"
+# define UCI_VERSION "v31.4"
 
 # ifdef PRIu64
 #  define FMT_INFO PRIu64

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -471,6 +471,11 @@ score_t qsearch(board_t *board, score_t alpha, score_t beta, searchstack_t *ss, 
 
     while ((currmove = movepick_next_move(&mp, false)) != NO_MOVE)
     {
+        // Only analyse good capture moves.
+
+        if (bestScore > -MATE_FOUND && mp.stage == PICK_BAD_INSTABLE)
+            break ;
+
         if (!move_is_legal(board, currmove))
             continue ;
 
@@ -487,11 +492,6 @@ score_t qsearch(board_t *board, score_t alpha, score_t beta, searchstack_t *ss, 
             if (delta < alpha)
                 continue ;
         }
-
-        // Only analyse good capture moves.
-
-        if (bestScore > -MATE_FOUND && !see_greater_than(board, currmove, 0))
-            continue ;
 
         ss->currentMove = currmove;
         {


### PR DESCRIPTION

This should act as both a speedup by reducing the number of see_greater_than() and move_is_legal() calls,
and (hopefully) slightly improve analysis by not pruning the TT move based on SEE in qsearch.

Bench: 10,366,635