### PR TITLE
Various tuning improvements

### DIFF
--- a/src/include/tuner.h
+++ b/src/include/tuner.h
@@ -80,7 +80,7 @@ void compute_gradient(const tune_data_t *data, tp_vector_t gradient, const tp_ve
 void update_gradient(const tune_entry_t *entry, tp_vector_t gradient, const tp_vector_t delta, double K);
 double adjusted_eval(const tune_entry_t *entry, const tp_vector_t delta, double safetyScores[COLOR_NB][PHASE_NB]);
 double static_eval_mse(const tune_data_t *data, double K);
-void adjusted_eval_mse(const tune_data_t *data, const tp_vector_t delta, double K, double resultPair[2], size_t split);
+double adjusted_eval_mse(const tune_data_t *data, const tp_vector_t delta, double K);
 double sigmoid(double K, double E);
 void print_parameters(const tp_vector_t base, const tp_vector_t delta);
 

--- a/src/include/uci.h
+++ b/src/include/uci.h
@@ -26,7 +26,7 @@
 # include <time.h>
 # include "inlining.h"
 
-# define UCI_VERSION "v31.4"
+# define UCI_VERSION "v31.5"
 
 # ifdef PRIu64
 #  define FMT_INFO PRIu64


### PR DESCRIPTION
- Removed the validation loss, since the eval never overfits for datasets > 500k positions
- Fixed core usage in parallel loops, now always using the correct amount of threads
- Fixed gradient updating, now using a mutex to avoid concurrent writes to the gradient array
- Fixed dataset generation, now simply filtering non-quiet positions, no playouts applied

Bench: 10,366,635