### PR TITLE
Add more draw rules for endgames with pawns on one side

### DIFF
--- a/src/include/bitboard.h
+++ b/src/include/bitboard.h
@@ -273,7 +273,7 @@ INLINED square_t bb_first_sq(bitboard_t b)
 
 INLINED square_t bb_last_sq(bitboard_t b)
 {
-    return (SQ_A8 ^ __builtin_clzll(b));
+    return (SQ_H8 ^ __builtin_clzll(b));
 }
 
 # elif defined(_MSC_VER)

--- a/src/include/endgame.h
+++ b/src/include/endgame.h
@@ -66,6 +66,7 @@ extern endgame_entry_t EndgameTable[EGTB_SIZE];
 
 void init_endgame_table(void);
 void init_kpk_bitbase(void);
+bool kpk_is_winning(color_t stm, square_t bksq, square_t wksq, square_t psq);
 
 score_t eval_draw(const board_t *board, color_t winningSide);
 score_t eval_krkn(const board_t *board, color_t winningSide);
@@ -75,7 +76,9 @@ score_t eval_kbnk(const board_t *board, color_t winningSide);
 score_t eval_kqkr(const board_t *board, color_t winningSide);
 score_t eval_kqkp(const board_t *board, color_t winningSide);
 score_t eval_kpk(const board_t *board, color_t winningSide);
+score_t eval_kpsk(const board_t *board, color_t winningSide);
 score_t eval_knnkp(const board_t *board, color_t winningSide);
+score_t eval_kbpsk(const board_t *board, color_t winningSide);
 
 const endgame_entry_t *endgame_probe(const board_t *board);
 

--- a/src/include/uci.h
+++ b/src/include/uci.h
@@ -26,7 +26,7 @@
 # include <time.h>
 # include "inlining.h"
 
-# define UCI_VERSION "v31.5"
+# define UCI_VERSION "v31.6"
 
 # ifdef PRIu64
 #  define FMT_INFO PRIu64

--- a/src/sources/endgame.c
+++ b/src/sources/endgame.c
@@ -257,6 +257,56 @@ score_t eval_krpkr(const board_t *board, color_t winningSide)
     return (score);
 }
 
+score_t eval_kbpsk(const board_t *board, color_t winningSide)
+{
+    pawn_entry_t *pe = pawn_probe(board);
+    score_t score = endgame_score(pe->value + board->psqScorePair);
+    color_t losingSide = not_color(winningSide);
+
+    square_t winningKsq = relative_sq(get_king_square(board, winningSide), winningSide);
+    square_t winningBsq = relative_sq(bb_first_sq(piecetype_bb(board, BISHOP)), winningSide);
+    square_t losingKsq = relative_sq(get_king_square(board, losingSide), winningSide);
+    bitboard_t winningPawns = piecetype_bb(board, PAWN);
+    bitboard_t wrongFile = (square_bb(winningBsq) & DARK_SQUARES) ? FILE_A_BITS : FILE_H_BITS;
+
+    if ((winningPawns & wrongFile) == winningPawns)
+    {
+        square_t mostAdvancedPawn = (winningSide == WHITE)
+            ? bb_last_sq(winningPawns)
+            : bb_first_sq(winningPawns) ^ SQ_A8;
+        color_t us = (board->sideToMove == winningSide) ? WHITE : BLACK;
+
+        if (!kpk_is_winning(us, losingKsq, winningKsq, mostAdvancedPawn))
+            return (0);
+    }
+
+    return (board->sideToMove == WHITE ? score : -score);
+}
+
+score_t eval_kpsk(const board_t *board, color_t winningSide)
+{
+    pawn_entry_t *pe = pawn_probe(board);
+    score_t score = endgame_score(pe->value + board->psqScorePair);
+    color_t losingSide = not_color(winningSide);
+
+    square_t winningKsq = relative_sq(get_king_square(board, winningSide), winningSide);
+    square_t losingKsq = relative_sq(get_king_square(board, losingSide), winningSide);
+    bitboard_t winningPawns = piecetype_bb(board, PAWN);
+
+    if ((winningPawns & FILE_A_BITS) == winningPawns || (winningPawns & FILE_H_BITS) == winningPawns)
+    {
+        square_t mostAdvancedPawn = (winningSide == WHITE)
+            ? bb_last_sq(winningPawns)
+            : bb_first_sq(winningPawns) ^ SQ_A8;
+        color_t us = (board->sideToMove == winningSide) ? WHITE : BLACK;
+
+        if (!kpk_is_winning(us, losingKsq, winningKsq, mostAdvancedPawn))
+            return (0);
+    }
+
+    return (board->sideToMove == WHITE ? score : -score);
+}
+
 void add_colored_entry(color_t winningSide, char *wpieces, char *bpieces, endgame_func_t func)
 {
     char bcopy[16];
@@ -329,6 +379,21 @@ void init_endgame_table(void)
     add_endgame_entry("KBPvKN", &eval_kmpkn);
     add_endgame_entry("KNPvKB", &eval_kmpkb);
     add_endgame_entry("KBPvKB", &eval_kmpkb);
+
+    // KPsK endgames
+
+    add_endgame_entry("KPPvK", &eval_kpsk);
+    add_endgame_entry("KPPPvK", &eval_kpsk);
+    add_endgame_entry("KPPPPvK", &eval_kpsk);
+    add_endgame_entry("KPPPPPvK", &eval_kpsk);
+    
+    // KBPsK endgames
+
+    add_endgame_entry("KBPvK", &eval_kbpsk);
+    add_endgame_entry("KBPPvK", &eval_kbpsk);
+    add_endgame_entry("KBPPPvK", &eval_kbpsk);
+    add_endgame_entry("KBPPPPvK", &eval_kbpsk);
+    add_endgame_entry("KBPPPPPvK", &eval_kbpsk);
 
     add_endgame_entry("KBNvK", &eval_kbnk);
 }

--- a/src/sources/kpk_bitbase.c
+++ b/src/sources/kpk_bitbase.c
@@ -53,7 +53,7 @@ INLINED unsigned int kpk_index(color_t stm, square_t bksq, square_t wksq, square
             );
 }
 
-INLINED bool kpk_is_winning(color_t stm, square_t bksq, square_t wksq, square_t psq)
+bool kpk_is_winning(color_t stm, square_t bksq, square_t wksq, square_t psq)
 {
     unsigned int index = kpk_index(stm, bksq, wksq, psq);
 


### PR DESCRIPTION
Fix eval for King + Bishop + Pawns vs lone King, and King + Pawns vs lone King when the endgame is clearly drawn

Bench: 10,366,635