### PR TITLE
Cap uniformly history bonus at 2000

### DIFF
--- a/src/include/history.h
+++ b/src/include/history.h
@@ -39,7 +39,7 @@ typedef move_t countermove_history_t[PIECE_NB][SQUARE_NB];
 
 INLINED int history_bonus(int depth)
 {
-    return (depth <= 12 ? 16 * depth * depth : 20);
+    return (depth <= 11 ? 14 * depth * depth : 2000);
 }
 
 INLINED void add_bf_history(butterfly_history_t hist, piece_t piece, move_t move, int32_t bonus)

--- a/src/include/uci.h
+++ b/src/include/uci.h
@@ -26,7 +26,7 @@
 # include <time.h>
 # include "lazy_smp.h"
 
-# define UCI_VERSION "v31.14"
+# define UCI_VERSION "v31.15"
 
 # if (SIZE_MAX == UINT64_MAX)
 #  define FMT_INFO PRIu64


### PR DESCRIPTION
Also reduce the history bonus scaling constant from 16 to 14.

Bench: 9,941,475