### PR TITLE
Fixed compilation issues with GCC 12

### DIFF
--- a/src/sources/tt.c
+++ b/src/sources/tt.c
@@ -50,6 +50,12 @@ void *tt_bzero_thread(void *data)
 
 void tt_bzero(size_t threadCount)
 {
+    if (threadCount == 0)
+    {
+        fputs("Unable to zero TT: thread count equals zero\n", stderr);
+        exit(EXIT_FAILURE);
+    }
+
     tt_thread_t *threadList = malloc(sizeof(tt_thread_t) * threadCount);
 
     if (threadList == NULL)

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -28,7 +28,7 @@
 #include "types.h"
 #include "uci.h"
 
-#define UCI_VERSION "v32.18"
+#define UCI_VERSION "v32.19"
 
 const cmdlink_t commands[] =
 {


### PR DESCRIPTION
Added a check for threadCount == 0 during TT zeroing to fix false-positives
from GCC 12 on unitialized memory.