### PR TITLE
Improve engine behaviour on root draws

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -347,7 +347,7 @@ score_t search(
 
     if (pvNode && worker->seldepth < ss->plies + 1) worker->seldepth = ss->plies + 1;
 
-    if (WPool.stop || game_is_drawn(board, ss->plies)) return (draw_score(worker));
+    if (!rootNode && (WPool.stop || game_is_drawn(board, ss->plies))) return (draw_score(worker));
 
     if (ss->plies >= MAX_PLIES)
         return (!board->stack->checkers ? evaluate(board) : draw_score(worker));

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v33.16"
+#define UCI_VERSION "v33.17"
 
 // clang-format off
 


### PR DESCRIPTION
Avoid having weird mate scores reported when the root position is drawn by 3-fold repetition or 50-move rule during game analysis.

Bench: 7,146,374