### PR TITLE
Add UCI_ShowWDL support to the engine

### DIFF
--- a/src/include/uci.h
+++ b/src/include/uci.h
@@ -48,6 +48,8 @@ typedef struct _OptionFields
     bool chess960;
     bool ponder;
     bool debug;
+    bool showWDL;
+    bool normalizeScore;
 } OptionFields;
 
 extern pthread_attr_t WorkerSettings;

--- a/src/sources/main.c
+++ b/src/sources/main.c
@@ -36,7 +36,7 @@ Movelist UciSearchMoves;
 
 uint64_t Seed = 1048592ul;
 
-OptionFields UciOptionFields = {1, 16, 100, 1, false, false, false};
+OptionFields UciOptionFields = {1, 16, 100, 1, false, false, false, false, true};
 
 Timeman SearchTimeman;
 


### PR DESCRIPTION
- Normalize the returned score for the GUI so that we get a 50% winrate for a 100 cp eval at move 33 (ply 64). This can be disabled by setting the NormalizeScore option to false.
- Add support for the UCI_ShowWDL option to display estimated WDL stats based on score and ply. (optimal parameters were computed using https://github.com/vondele/WLD_model based on a sample of 4700 STC (8+0.08) games. Big thanks again to Disservin (Smallbrain's author) for the computing help.

  Bench: 8,055,172