### PR TITLE
Improve UCI support again

### DIFF
--- a/src/include/timeman.h
+++ b/src/include/timeman.h
@@ -75,6 +75,7 @@ typedef struct _Timeman
     clock_t start;
     timeman_mode_t mode;
     bool pondering;
+    int checkFrequency;
 
     clock_t averageTime;
     clock_t maximalTime;

--- a/src/sources/worker.c
+++ b/src/sources/worker.c
@@ -210,7 +210,7 @@ void wpool_new_search(WorkerPool *wpool)
     for (size_t i = 0; i < wpool->size; ++i) wpool->workerList[i]->verifPlies = 0;
 
     // Reset the periodical time checking counter as well.
-    wpool->checks = 1000;
+    wpool->checks = 1;
 }
 
 void wpool_reset(WorkerPool *wpool)
@@ -220,7 +220,7 @@ void wpool_reset(WorkerPool *wpool)
     for (size_t i = 0; i < wpool->size; ++i) worker_reset(wpool->workerList[i]);
 
     // Reset the periodical time checking counter as well.
-    wpool->checks = 1000;
+    wpool->checks = 1;
 }
 
 void wpool_start_search(WorkerPool *wpool, const Board *rootBoard, const SearchParams *searchParams)


### PR DESCRIPTION
- Output info strings during search as a single block of data to avoid blending stuff with the UCI thread and slightly improve speed.
- Increase verifications during FEN parsing by checking material count, Pawn placement and attacks on the opposite King.
- Add more debug strings to the search and option parsing.
- Improve timeman behaviour on 'go nodes' by increasing the check frequency when the node count is low.

Bench: 7,481,146