### PR TITLE
Improve the code base a little bit

### DIFF
--- a/ci_scripts/check_bench.sh
+++ b/ci_scripts/check_bench.sh
@@ -4,13 +4,13 @@
 
 echo "--- TEST: Bench value matching"
 
-_BENCHMARK=$(echo "$1" | fgrep "Bench:" | sed "s/Bench: //g" | tr -d ',')
+_BENCHMARK=$(echo "$1" | grep -m 1 -F "Bench:" | grep -o '[1-9,]\+' | tr -d ',')
 if test -z "$_BENCHMARK"
 then
     echo "--- WARNING: Missing bench field, skipping bench test"
 else
     echo "Expected bench: $_BENCHMARK"
-    _OUTPUT=$(./stash bench | fgrep "NODES:" | sed "s/NODES: //g")
+    _OUTPUT=$(./stash bench | grep -m 1 -F "NODES:" | grep -o '[1-9]\+')
     echo "Our bench: $_OUTPUT"
     if test "$_BENCHMARK" != "$_OUTPUT"
     then
@@ -51,12 +51,12 @@ send "quit\n"
 expect eof
 EOF
 
-for i in `seq 1 20`
+for i in $(seq 1 20)
 do
     nodes=$((100*3**i/2**i))
     echo "--- TEST: reprosearch with $nodes nodes"
 
-    expect repeat.exp $nodes 2>&1 | grep -o "nodes [0-9]*" | sort | uniq -c | awk '{if ($1%2!=0) exit(1)}'
+    expect repeat.exp $nodes 2>&1 | grep -o 'nodes [0-9]\+' | sort | uniq -c | awk '{if ($1%2!=0) exit(1)}'
     if test $? != 0
     then
         echo "--- ERROR: failed reprosearch"

--- a/src/include/option.h
+++ b/src/include/option.h
@@ -58,7 +58,7 @@ typedef enum option_type_e
         char __buf[128];                                                                \
         for (int __i = start; __i < end; ++__i)                                         \
         {                                                                               \
-            sprintf(__buf, #x "_%02d", __i);                                            \
+            snprintf(__buf, 128, #x "_%02d", __i);                                      \
             add_option_scorepair(&UciOptionList, __buf, &x[__i], SPAIR(minval, minval), \
                 SPAIR(maxval, maxval), NULL);                                           \
         }                                                                               \

--- a/src/sources/board.c
+++ b/src/sources/board.c
@@ -92,7 +92,8 @@ static bool board_invalid_material(const Board *board, color_t c)
 
     pawns += promoted;
 
-    return (pawns > 8) || (knights + pawns - pknights > 10) || (bishops + pawns - pbishops > 10) || (rooks + pawns - prooks > 10) || (queens + pawns - pqueens > 9);
+    return (pawns > 8) || (knights + pawns - pknights > 10) || (bishops + pawns - pbishops > 10)
+           || (rooks + pawns - prooks > 10) || (queens + pawns - pqueens > 9);
 }
 
 static int board_parse_fen_pieces(Board *board, const char *fen)

--- a/src/sources/option.c
+++ b/src/sources/option.c
@@ -283,13 +283,15 @@ bool try_set_option_spin_int(Option *option, const char *value)
 
     if (endptr == value)
     {
-        debug_printf("info error Failed to parse value '%s' for option '%s'\n", value, option->name);
+        debug_printf(
+            "info error Failed to parse value '%s' for option '%s'\n", value, option->name);
         return false;
     }
 
     if (ivalue < *(long *)option->min || ivalue > *(long *)option->max)
     {
-        debug_printf("info error Value '%s' falls outside of the supported range for option '%s'\n", value, option->name);
+        debug_printf("info error Value '%s' falls outside of the supported range for option '%s'\n",
+            value, option->name);
         return false;
     }
 
@@ -305,13 +307,15 @@ bool try_set_option_spin_flt(Option *option, const char *value)
 
     if (endptr == value)
     {
-        debug_printf("info error Failed to parse value '%s' for option '%s'\n", value, option->name);
+        debug_printf(
+            "info error Failed to parse value '%s' for option '%s'\n", value, option->name);
         return false;
     }
 
     if (fvalue < *(double *)option->min || fvalue > *(double *)option->max)
     {
-        debug_printf("info error Value '%s' falls outside of the supported range for option '%s'\n", value, option->name);
+        debug_printf("info error Value '%s' falls outside of the supported range for option '%s'\n",
+            value, option->name);
         return false;
     }
 
@@ -327,13 +331,15 @@ bool try_set_option_score(Option *option, const char *value)
 
     if (endptr == value)
     {
-        debug_printf("info error Failed to parse value '%s' for option '%s'\n", value, option->name);
+        debug_printf(
+            "info error Failed to parse value '%s' for option '%s'\n", value, option->name);
         return false;
     }
 
     if (ivalue < (long)*(score_t *)option->min || ivalue > (long)*(score_t *)option->max)
     {
-        debug_printf("info error Value '%s' falls outside of the supported range for option '%s'\n", value, option->name);
+        debug_printf("info error Value '%s' falls outside of the supported range for option '%s'\n",
+            value, option->name);
         return false;
     }
 
@@ -349,13 +355,15 @@ bool try_set_option_scorepair(Option *option, const char *value)
 
     if (endptr == value)
     {
-        debug_printf("info error Failed to parse value '%s' for option '%s'\n", value, option->name);
+        debug_printf(
+            "info error Failed to parse value '%s' for option '%s'\n", value, option->name);
         return false;
     }
 
     if (ivalue < (long)*(score_t *)option->min || ivalue > (long)*(score_t *)option->max)
     {
-        debug_printf("info error Value '%s' falls outside of the supported range for option '%s'\n", value, option->name);
+        debug_printf("info error Value '%s' falls outside of the supported range for option '%s'\n",
+            value, option->name);
         return false;
     }
 
@@ -386,7 +394,8 @@ bool try_set_option_check(Option *option, const char *value)
     }
     else
     {
-        debug_printf("info error Value '%s' for option '%s' is not a boolean\n", value, option->name);
+        debug_printf(
+            "info error Value '%s' for option '%s' is not a boolean\n", value, option->name);
         return false;
     }
 
@@ -399,7 +408,8 @@ bool try_set_option_string(Option *option, const char *value)
 
     if (vcopy == NULL)
     {
-        debug_printf("info error Unable to set value '%s' for option '%s': %s\n", value, option->name, strerror(errno));
+        debug_printf("info error Unable to set value '%s' for option '%s': %s\n", value,
+            option->name, strerror(errno));
         return false;
     }
 
@@ -415,7 +425,8 @@ bool try_set_option_combo(Option *option, const char *value)
         if (strcasecmp(option->comboList[i], value) == 0)
             return try_set_option_string(option, option->comboList[i]);
 
-    debug_printf("info error value '%s' is not in the list of supported values for option '%s'\n", value, option->name);
+    debug_printf("info error value '%s' is not in the list of supported values for option '%s'\n",
+        value, option->name);
     return false;
 }
 
@@ -447,34 +458,20 @@ void set_option(OptionList *list, const char *name, const char *value)
             // accepted names for combo lists.
             switch (cur->type)
             {
-                case OptionSpinInt:
-                    set_success = try_set_option_spin_int(cur, value);
-                    break;
+                case OptionSpinInt: set_success = try_set_option_spin_int(cur, value); break;
 
-                case OptionSpinFlt:
-                    set_success = try_set_option_spin_flt(cur, value);
-                    break;
+                case OptionSpinFlt: set_success = try_set_option_spin_flt(cur, value); break;
 
-                case OptionScore:
-                    set_success = try_set_option_score(cur, value);
-                    break;
+                case OptionScore: set_success = try_set_option_score(cur, value); break;
 
                 case OptionSpairMG:
-                case OptionSpairEG:
-                    set_success = try_set_option_scorepair(cur, value);
-                    break;
+                case OptionSpairEG: set_success = try_set_option_scorepair(cur, value); break;
 
-                case OptionCheck:
-                    set_success = try_set_option_check(cur, value);
-                    break;
+                case OptionCheck: set_success = try_set_option_check(cur, value); break;
 
-                case OptionString:
-                    set_success = try_set_option_string(cur, value);
-                    break;
+                case OptionString: set_success = try_set_option_string(cur, value); break;
 
-                case OptionCombo:
-                    set_success = try_set_option_combo(cur, value);
-                    break;
+                case OptionCombo: set_success = try_set_option_combo(cur, value); break;
 
                 case OptionButton:
                     debug_printf("info string Setting option '%s'\n", cur->name);
@@ -482,9 +479,7 @@ void set_option(OptionList *list, const char *name, const char *value)
                     break;
 
                 // This shouldn't be executed, keep it as a safeguard.
-                default:
-                    set_success = false;
-                    break;
+                default: set_success = false; break;
             }
 
             // Only call bound functions if the option setting was successful.

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -690,8 +690,7 @@ __main_loop:
                 if (alpha >= beta)
                 {
                     // Update move histories.
-                    if (isQuiet)
-                        update_quiet_history(board, depth, bestmove, quiets, qcount, ss);
+                    if (isQuiet) update_quiet_history(board, depth, bestmove, quiets, qcount, ss);
                     if (moveCount != 1)
                         update_capture_history(board, depth, bestmove, captures, ccount, ss);
                     break;

--- a/src/sources/timeman.c
+++ b/src/sources/timeman.c
@@ -35,15 +35,11 @@ const double BestmoveTypeScale[BM_TYPE_NB] = {
     1.40, // Quiet losing material
 };
 
-INLINED clock_t timemin(clock_t left, clock_t right)
-{
-    return (left < right) ? left : right;
-}
+INLINED clock_t timemin(clock_t left, clock_t right) { return (left < right) ? left : right; }
 
-INLINED clock_t timemax(clock_t left, clock_t right)
-{
-    return (left > right) ? left : right;
-}
+// Unused for now, commented to avoid compilation issues with the function being
+// declared static. Uncomment if needed for time management code updates.
+// INLINED clock_t timemax(clock_t left, clock_t right) { return (left > right) ? left : right; }
 
 // Scaling table based on the number of consecutive iterations the bestmove held
 const double BestmoveStabilityScale[5] = {2.50, 1.20, 0.90, 0.80, 0.75};
@@ -56,8 +52,7 @@ void timeman_init(const Board *board, Timeman *tm, SearchParams *params, clock_t
     tm->pondering = false;
     tm->checkFrequency = 1000;
 
-    if (params->nodes)
-        tm->checkFrequency = (int)fmin(1000.0, sqrt(params->nodes) + 0.5);
+    if (params->nodes) tm->checkFrequency = (int)fmin(1000.0, sqrt(params->nodes) + 0.5);
 
     if (params->wtime || params->btime)
     {
@@ -91,7 +86,8 @@ void timeman_init(const Board *board, Timeman *tm, SearchParams *params, clock_t
     else if (params->movetime)
     {
         tm->mode = Movetime;
-        tm->averageTime = tm->maximalTime = tm->optimalTime = (params->movetime <= overhead) ? 1 : (params->movetime - overhead);
+        tm->averageTime = tm->maximalTime = tm->optimalTime =
+            (params->movetime <= overhead) ? 1 : (params->movetime - overhead);
 
         // Log the maximal time in debug mode.
         debug_printf("info maximal_time %" FMT_INFO "\n", (info_t)tm->maximalTime);

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -30,7 +30,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.6"
+#define UCI_VERSION "v34.7"
 
 // clang-format off
 
@@ -204,7 +204,7 @@ void print_pv(
 
     // At most 256 moves stored in (each taking 5 bytes) + 16 more bytes for
     // potential promotions + 1 byte for the final nullbyte.
-    char pvBuffer[256*5+16+1] = {0};
+    char pvBuffer[256 * 5 + 16 + 1] = {0};
 
     // Fill the PV buffer.
     for (size_t i = 0; rootMove->pv[i]; ++i)
@@ -371,8 +371,7 @@ void uci_position(const char *args)
 
     int result = board_from_fen(&UciBoard, fen, UciOptionFields.chess960, *hiddenList);
 
-    if (result < 0)
-        board_from_fen(&UciBoard, StartPosFEN, UciOptionFields.chess960, *hiddenList);
+    if (result < 0) board_from_fen(&UciBoard, StartPosFEN, UciOptionFields.chess960, *hiddenList);
 
     UciBoard.worker = wpool_main_worker(&SearchWorkerPool);
     free(fen);
@@ -395,8 +394,8 @@ void uci_position(const char *args)
         }
 
         if (token)
-            debug_printf("info string Failed to parse move token #%lu ('%s')\n",
-                (unsigned long)i, token);
+            debug_printf(
+                "info string Failed to parse move token #%lu ('%s')\n", (unsigned long)i, token);
         debug_printf("info string Final board state: %s\n", board_fen(&UciBoard));
     }
 


### PR DESCRIPTION
- Use explicit buffer limitations in TUNE_SP_ARRAY() macro
- Replace fgrep calls for bench parsing in commits by grep -F
- Make the bench format a little more flexible for the CI by allowing several whitespaces before and after the 'Bench:' token
- Replace backquotes by dollar expansions in shell scripts for command substitution
- Comment out the timemax() function in timeman.c to avoid compilation errors from an unused static function
- Improve the bookgen script by not analyzing the same position twice and resetting the engine state after each searched position
- Increase slightly the number of candidate PV lines for book generation
- Remove os.system() calls in the extract script by providing argument lists to subprocess.run()
- Reduce memory usage during FEN extraction by writing directly the sampled FENs to the thread-specific file
- Reformat some sections of the code and scripts

Bench: 7,481,146