### PR TITLE
Introduce double extensions

### DIFF
--- a/src/include/search.h
+++ b/src/include/search.h
@@ -26,6 +26,7 @@
 typedef struct _Searchstack
 {
     int plies;
+    int doubleExtensions;
     score_t staticEval;
     move_t killers[2];
     move_t excludedMove;

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -575,13 +575,15 @@ __main_loop:
 
                 // Our singular search failed to produce a cutoff, extend the TT
                 // move.
-                if (singularScore < singularBeta) {
-                    if (!pvNode && singularBeta - singularScore > 24 && ss->doubleExtensions <= 5) {
+                if (singularScore < singularBeta)
+                {
+                    if (!pvNode && singularBeta - singularScore > 24 && ss->doubleExtensions <= 5)
+                    {
                         extension = 2;
                         ss->doubleExtensions++;
-                    } else {
-                        extension = 1;
                     }
+                    else
+                        extension = 1;
                 }
 
                 // Multicut Pruning. If our singular search produced a cutoff,

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -574,7 +574,12 @@ __main_loop:
 
                 // Our singular search failed to produce a cutoff, extend the TT
                 // move.
-                if (singularScore < singularBeta) extension = 1;
+                if (singularScore < singularBeta) {
+                    if (!pvNode && singularBeta - singularScore > 24)
+                        extension = 2;
+                    else
+                        extension = 1;
+                }
 
                 // Multicut Pruning. If our singular search produced a cutoff,
                 // and the search bounds were equal or superior to our normal

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -397,6 +397,7 @@ score_t search(Board *board, int depth, score_t alpha, score_t beta, Searchstack
     }
 
     (ss + 2)->killers[0] = (ss + 2)->killers[1] = NO_MOVE;
+    ss->doubleExtensions = (ss - 1)->doubleExtensions;
 
     // Don't perform early pruning or compute the eval while in check.
     if (inCheck)
@@ -575,10 +576,12 @@ __main_loop:
                 // Our singular search failed to produce a cutoff, extend the TT
                 // move.
                 if (singularScore < singularBeta) {
-                    if (!pvNode && singularBeta - singularScore > 24)
+                    if (!pvNode && singularBeta - singularScore > 24 && ss->doubleExtensions <= 5) {
                         extension = 2;
-                    else
+                        ss->doubleExtensions++;
+                    } else {
                         extension = 1;
+                    }
                 }
 
                 // Multicut Pruning. If our singular search produced a cutoff,

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.15"
+#define UCI_VERSION "v34.16"
 
 // clang-format off
 


### PR DESCRIPTION
Introduce double extensions, capped at 5 double extensions to avoid search explosions.

Passed STC:
```
ELO   | 11.24 +- 6.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4544 W: 948 L: 801 D: 2795
```
http://chess.grantnet.us/test/32702/

Passed LTC:
```
ELO   | 10.09 +- 5.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4720 W: 741 L: 604 D: 3375
```
http://chess.grantnet.us/test/32703/

Bench: 8,518,688