### PR TITLE
Handtune LMR log formula

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -35,7 +35,7 @@ void init_search_tables(void)
 {
     // Compute the LMR base values based on depth and movecount.
     for (int d = 1; d < 64; ++d)
-        for (int m = 1; m < 64; ++m) Reductions[d][m] = -1.34 + log(d) * log(m) / 1.26;
+        for (int m = 1; m < 64; ++m) Reductions[d][m] = -0.84 + log(d) * log(m) / 1.46;
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 7; ++d)

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.18"
+#define UCI_VERSION "v34.19"
 
 // clang-format off
 


### PR DESCRIPTION
Make the formula less aggressive after recent LMR patches.

Passed STC:
```
ELO   | 3.96 +- 3.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 19112 W: 3925 L: 3707 D: 11480
```
http://chess.grantnet.us/test/32795/

Passed LTC:
```
ELO   | 3.23 +- 2.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 21272 W: 3258 L: 3060 D: 14954
```
http://chess.grantnet.us/test/32797/