### PR TITLE
Fix compilation issues on Windows from ctype calls

### DIFF
--- a/src/sources/board.c
+++ b/src/sources/board.c
@@ -287,9 +287,9 @@ static int board_parse_castling(Board *board, const char *fen)
         }
 
         square_t rookSquare;
-        const color_t side = islower(fen[i]) ? BLACK : WHITE;
+        const color_t side = islower((unsigned char)fen[i]) ? BLACK : WHITE;
         const piece_t rook = create_piece(side, ROOK);
-        const char castlingChar = toupper(fen[i]);
+        const char castlingChar = toupper((unsigned char)fen[i]);
 
         // Compute the rook square based on the parsed character.
         if (castlingChar == 'K')
@@ -340,7 +340,7 @@ static int board_parse_en_passant(Board *board, const char *fen)
     else if (nextSection <= 1)
         return nextSection;
 
-    const char fileChar = tolower(fen[0]);
+    const char fileChar = fen[0];
     const char rankChar = fen[1];
 
     // Check that the en-passant square is correctly formatted and valid for the side to move.

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.21"
+#define UCI_VERSION "v34.22"
 
 // clang-format off
 
@@ -71,13 +71,13 @@ __attribute__((noreturn)) static void uci_allocation_failure(const char *str)
 // on MinGW.
 char *get_next_token(char **str)
 {
-    while (isspace(**str) && **str != '\0') ++(*str);
+    while (isspace((unsigned char)**str) && **str != '\0') ++(*str);
 
     if (**str == '\0') return NULL;
 
     char *retval = *str;
 
-    while (!isspace(**str) && **str != '\0') ++(*str);
+    while (!isspace((unsigned char)**str) && **str != '\0') ++(*str);
 
     if (**str == '\0') return retval;
 


### PR DESCRIPTION
Fix errors being thrown on Windows in character test function calls due to them being macros accessing arrays directly with the parameter as an index.
Closes #117.

Bench: 8,149,735