### PR TITLE
Lower LMR movecount threshold for non-PV nodes

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -622,7 +622,7 @@ __main_loop:
         do_move_gc(board, currmove, &stack, givesCheck);
         atomic_fetch_add_explicit(&get_worker(board)->nodes, 1, memory_order_relaxed);
 
-        const bool do_lmr = depth >= 3 && moveCount > 2 + 2 * pvNode;
+        const bool do_lmr = depth >= 3 && moveCount > 1 + 3 * pvNode;
 
         // Late Move Reductions. For nodes not too close to qsearch (since
         // we can't reduce their search depth), we start reducing moves after

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.22"
+#define UCI_VERSION "v34.23"
 
 // clang-format off
 


### PR DESCRIPTION
Passed LTC:

```
ELO   | 1.82 +- 1.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 73304 W: 10867 L: 10484 D: 51953
```
http://chess.grantnet.us/test/32900/

Bench: 7,685,281