### PR TITLE
Fix the sign of KBPsvK evals when using distance penalty

### DIFF
--- a/src/sources/endgame.c
+++ b/src/sources/endgame.c
@@ -261,6 +261,8 @@ score_t eval_kbpsk(const Board *board, color_t winningSide)
     bitboard_t winningPawns = piecetype_bb(board, PAWN);
     bitboard_t wrongFile = (square_bb(winningBsq) & DARK_SQUARES) ? FILE_A_BB : FILE_H_BB;
 
+    if (board->sideToMove == BLACK) score = -score;
+
     // Check for a wrong-colored bishop situation.
     if ((winningPawns & wrongFile) == winningPawns)
     {
@@ -274,7 +276,7 @@ score_t eval_kbpsk(const Board *board, color_t winningSide)
         return score * (queeningDistance - 1) / queeningDistance;
     }
 
-    return board->sideToMove == WHITE ? score : -score;
+    return score;
 }
 
 score_t eval_kpsk(const Board *board, color_t winningSide)

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.24"
+#define UCI_VERSION "v34.25"
 
 // clang-format off
 


### PR DESCRIPTION
Passed non-regression STC:

```
ELO   | 1.39 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 18952 W: 3810 L: 3734 D: 11408
```
http://chess.grantnet.us/test/33023/

Bench: 7,987,179