### PR TITLE
Increase size of aspiration window for larger evals

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -226,7 +226,7 @@ void worker_search(worker_t *worker)
 
             // Don't set aspiration window bounds for low depths, as the scores are
             // very volatile.
-            if (iterDepth <= 9)
+            if (iterDepth <= 7)
             {
                 delta = 0;
                 alpha = -INF_SCORE;
@@ -234,7 +234,7 @@ void worker_search(worker_t *worker)
             }
             else
             {
-                delta = 15;
+                delta = 12 + pvScore * pvScore / 16384;
                 alpha = imax(-INF_SCORE, pvScore - delta);
                 beta = imin(INF_SCORE, pvScore + delta);
             }

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.25"
+#define UCI_VERSION "v34.26"
 
 // clang-format off
 


### PR DESCRIPTION
Inspired by https://github.com/official-stockfish/Stockfish/commit/717d6c5ed503543c66eb7a2c10e8a97c88d99862

Passed STC:
```
ELO   | 3.06 +- 2.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 30104 W: 6064 L: 5799 D: 1824
```
http://chess.grantnet.us/test/33120/

Passed LTC:
```
ELO   | 3.40 +- 2.64 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 19408 W: 2931 L: 2741 D: 13736
```
http://chess.grantnet.us/test/33135/

Bench: 8,140,736