### PR TITLE
Tune endgame scaling constants

### DIFF
--- a/src/sources/evaluate.c
+++ b/src/sources/evaluate.c
@@ -261,14 +261,14 @@ score_t scale_endgame(const Board *board, const PawnEntry *pe, score_t eg)
     if (!strongPawns && strongMat - weakMat <= BISHOP_MG_SCORE)
         factor = (strongMat <= BISHOP_MG_SCORE)
                      ? 0
-                     : imax((int32_t)(strongMat - weakMat) * 15 / BISHOP_MG_SCORE / 2, 0);
+                     : imax((int32_t)(strongMat - weakMat) * 16 / BISHOP_MG_SCORE / 2, 0);
 
     // OCB endgames: scale based on the number of remaining pieces of the strong side,
     // or if there are no other remaining pieces, based on the number of passed pawns.
     else if (ocb_endgame(board))
         factor = (strongMat + weakMat > 2 * BISHOP_MG_SCORE)
-                     ? 71 + popcount(color_bb(board, strongSide)) * 10
-                     : 35 + popcount(pe->passed[strongSide]) * 19;
+                     ? 71 + popcount(color_bb(board, strongSide)) * 9
+                     : 33 + popcount(pe->passed[strongSide]) * 21;
 
     // Rook endgames: drawish if the Pawn advantage is small, and all strong side Pawns
     // are on the same side of the board. Don't scale if the defending King is far from
@@ -277,12 +277,12 @@ score_t scale_endgame(const Board *board, const PawnEntry *pe, score_t eg)
              && (popcount(strongPawns) - popcount(weakPawns) < 2)
              && !!(KINGSIDE_BB & strongPawns) != !!(QUEENSIDE_BB & strongPawns)
              && (king_moves(get_king_square(board, weakSide)) & weakPawns))
-        factor = 117;
+        factor = 130;
 
     // Other endgames. Decrease the endgame score as the number of pawns of the strong
     // side gets lower.
     else
-        factor = imin(256, 189 + 13 * popcount(strongPawns));
+        factor = imin(256, 177 + 13 * popcount(strongPawns));
 
     // Be careful to cast to 32-bit integer here before multiplying to avoid overflows.
     eg = (score_t)((int32_t)eg * factor / 256);

--- a/src/sources/evaluate.c
+++ b/src/sources/evaluate.c
@@ -261,14 +261,14 @@ score_t scale_endgame(const Board *board, const PawnEntry *pe, score_t eg)
     if (!strongPawns && strongMat - weakMat <= BISHOP_MG_SCORE)
         factor = (strongMat <= BISHOP_MG_SCORE)
                      ? 0
-                     : imax((int32_t)(strongMat - weakMat) * 8 / BISHOP_MG_SCORE, 0);
+                     : imax((int32_t)(strongMat - weakMat) * 15 / BISHOP_MG_SCORE / 2, 0);
 
     // OCB endgames: scale based on the number of remaining pieces of the strong side,
     // or if there are no other remaining pieces, based on the number of passed pawns.
     else if (ocb_endgame(board))
         factor = (strongMat + weakMat > 2 * BISHOP_MG_SCORE)
-                     ? 36 + popcount(color_bb(board, strongSide)) * 6
-                     : 16 + popcount(pe->passed[strongSide]) * 8;
+                     ? 71 + popcount(color_bb(board, strongSide)) * 10
+                     : 35 + popcount(pe->passed[strongSide]) * 19;
 
     // Rook endgames: drawish if the Pawn advantage is small, and all strong side Pawns
     // are on the same side of the board. Don't scale if the defending King is far from
@@ -277,15 +277,15 @@ score_t scale_endgame(const Board *board, const PawnEntry *pe, score_t eg)
              && (popcount(strongPawns) - popcount(weakPawns) < 2)
              && !!(KINGSIDE_BB & strongPawns) != !!(QUEENSIDE_BB & strongPawns)
              && (king_moves(get_king_square(board, weakSide)) & weakPawns))
-        factor = 64;
+        factor = 117;
 
     // Other endgames. Decrease the endgame score as the number of pawns of the strong
     // side gets lower.
     else
-        factor = imin(128, 96 + 8 * popcount(strongPawns));
+        factor = imin(256, 189 + 13 * popcount(strongPawns));
 
     // Be careful to cast to 32-bit integer here before multiplying to avoid overflows.
-    eg = (score_t)((int32_t)eg * factor / 128);
+    eg = (score_t)((int32_t)eg * factor / 256);
     TRACE_FACTOR(factor);
 
     return eg;

--- a/src/sources/tuner.c
+++ b/src/sources/tuner.c
@@ -311,7 +311,7 @@ bool init_tuner_entry(tune_entry_t *entry, const Board *board)
     entry->eval = Trace.eval;
     entry->safety[WHITE] = Trace.safety[WHITE];
     entry->safety[BLACK] = Trace.safety[BLACK];
-    entry->scaleFactor = Trace.scaleFactor / 128.0;
+    entry->scaleFactor = Trace.scaleFactor / 256.0;
     entry->sideToMove = board->sideToMove;
     return true;
 }

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.26"
+#define UCI_VERSION "v34.27"
 
 // clang-format off
 


### PR DESCRIPTION
SPSA tuning at 1+0.01, 20k iterations.

Passed STC:

```
ELO   | 4.94 +- 3.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13304 W: 2709 L: 2520 D: 8075
```
http://chess.grantnet.us/test/33105/

Passed LTC:

```
ELO   | 2.24 +- 1.78 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 43120 W: 6541 L: 6263 D: 30316
```
http://chess.grantnet.us/test/33106/

Bench: 7,616,158