### PR TITLE
Fix the behavior of the aspiration window when values get really high

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -234,7 +234,7 @@ void worker_search(worker_t *worker)
             }
             else
             {
-                delta = 12 + pvScore * pvScore / 16384;
+                delta = imin(12 + pvScore * pvScore / 16384, 32000);
                 alpha = imax(-INF_SCORE, pvScore - delta);
                 beta = imin(INF_SCORE, pvScore + delta);
             }

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.28"
+#define UCI_VERSION "v34.29"
 
 // clang-format off
 


### PR DESCRIPTION
Passed non-regression STC:

```
ELO   | 0.95 +- 2.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 23504 W: 4644 L: 4580 D: 14280
```
http://chess.grantnet.us/test/33159/

Bench: 7,616,158