### PR TITLE
Use a 1D array for computing LMR values

### DIFF
--- a/src/include/search.h
+++ b/src/include/search.h
@@ -35,9 +35,6 @@ typedef struct _Searchstack
     piece_history_t *pieceHistory;
 } Searchstack;
 
-// Global for Late Move Reductions
-extern int Reductions[64][64];
-
 // Global for Late Move Pruning
 extern int Pruning[2][7];
 

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -28,14 +28,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int Reductions[64][64];
+static int Reductions[256];
 int Pruning[2][7];
 
 void init_search_tables(void)
 {
-    // Compute the LMR base values based on depth and movecount.
-    for (int d = 1; d < 64; ++d)
-        for (int m = 1; m < 64; ++m) Reductions[d][m] = -0.84 + log(d) * log(m) / 1.46;
+    // Compute the LMR base values.
+    for (int i = 1; i < 256; ++i)
+        Reductions[i] = (int)(log(i) * 26.5);
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 7; ++d)
@@ -43,6 +43,11 @@ void init_search_tables(void)
         Pruning[1][d] = +3.17 + 3.66 * pow(d, 1.09);
         Pruning[0][d] = -1.25 + 3.13 * pow(d, 0.65);
     }
+}
+
+int lmr_base_value(int depth, int movecount)
+{
+    return (-860 + Reductions[depth] * Reductions[movecount]) / 1024;
 }
 
 void init_searchstack(Searchstack *ss)
@@ -634,7 +639,7 @@ __main_loop:
             {
                 // Set the base depth reduction value based on depth and
                 // movecount.
-                R = Reductions[imin(depth, 63)][imin(moveCount, 63)];
+                R = lmr_base_value(depth, moveCount);
 
                 // Increase the reduction for non-PV nodes.
                 R += !pvNode;

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.29"
+#define UCI_VERSION "v34.30"
 
 // clang-format off
 


### PR DESCRIPTION
Passed non-regression STC:

```
ELO   | 2.45 +- 3.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 13200 W: 2674 L: 2581 D: 7945
```
http://chess.grantnet.us/test/33267/

Bench: 7,999,942