### PR TITLE
Tweak LMR log formula

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -28,14 +28,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static int Reductions[256];
+static double Reductions[256];
 int Pruning[2][7];
 
 void init_search_tables(void)
 {
     // Compute the LMR base values.
     for (int i = 1; i < 256; ++i)
-        Reductions[i] = (int)(log(i) * 26.5);
+        Reductions[i] = log(i) * 26.48;
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 7; ++d)
@@ -47,7 +47,7 @@ void init_search_tables(void)
 
 int lmr_base_value(int depth, int movecount)
 {
-    return (-860 + Reductions[depth] * Reductions[movecount]) / 1024;
+    return (int)(-860 + Reductions[depth] * Reductions[movecount]) / 1024;
 }
 
 void init_searchstack(Searchstack *ss)

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.30"
+#define UCI_VERSION "v34.31"
 
 // clang-format off
 


### PR DESCRIPTION
Use doubles to improve accuracy

Passed LTC:
```
ELO   | 5.71 +- 3.80 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9376 W: 1446 L: 1292 D: 6638
```
http://chess.grantnet.us/test/33288/