### PR TITLE
Do more singular extensions

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -582,7 +582,7 @@ __main_loop:
             if (depth >= 7 && currmove == ttMove && !ss->excludedMove && (ttBound & LOWER_BOUND)
                 && abs(ttScore) < VICTORY && ttDepth >= depth - 2)
             {
-                score_t singularBeta = ttScore - depth;
+                score_t singularBeta = ttScore - 3 * depth / 4;
                 int singularDepth = depth / 2;
 
                 // Exclude the TT move from the singular search.

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.31"
+#define UCI_VERSION "v34.32"
 
 // clang-format off
 


### PR DESCRIPTION
Reduce singularBeta depth margin.

Passed LTC:
```
ELO   | 2.50 +- 1.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 34560 W: 5047 L: 4798 D: 24715
```
http://chess.grantnet.us/test/33336/