### PR TITLE
Tune the LMR formula and quantize it again

### DIFF
--- a/src/include/search.h
+++ b/src/include/search.h
@@ -61,6 +61,7 @@ void update_capture_history(const Board *board, int depth, move_t bestmove,
 score_t qsearch(bool pvNode, Board *board, score_t alpha, score_t beta, Searchstack *ss);
 
 // Standard search.
-score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta, Searchstack *ss, bool cutNode);
+score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta, Searchstack *ss,
+    bool cutNode);
 
 #endif

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -28,14 +28,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static double Reductions[256];
+static int Reductions[256];
 int Pruning[2][7];
 
 void init_search_tables(void)
 {
     // Compute the LMR base values.
     for (int i = 1; i < 256; ++i)
-        Reductions[i] = log(i) * 26.48;
+        Reductions[i] = (int)(log(i) * 19.55 + 4.85);
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 7; ++d)
@@ -45,9 +45,9 @@ void init_search_tables(void)
     }
 }
 
-int lmr_base_value(int depth, int movecount)
+int lmr_base_value(int depth, int movecount, bool improving)
 {
-    return (int)(-860 + Reductions[depth] * Reductions[movecount]) / 1024;
+    return (-391 + Reductions[depth] * Reductions[movecount] + !improving * 642) / 1024;
 }
 
 void init_searchstack(Searchstack *ss)
@@ -639,7 +639,7 @@ __main_loop:
             {
                 // Set the base depth reduction value based on depth and
                 // movecount.
-                R = lmr_base_value(depth, moveCount);
+                R = lmr_base_value(depth, moveCount, improving);
 
                 // Increase the reduction for non-PV nodes.
                 R += !pvNode;

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -34,8 +34,7 @@ int Pruning[2][7];
 void init_search_tables(void)
 {
     // Compute the LMR base values.
-    for (int i = 1; i < 256; ++i)
-        Reductions[i] = (int)(log(i) * 22.70 + 8.70);
+    for (int i = 1; i < 256; ++i) Reductions[i] = (int)(log(i) * 22.70 + 8.70);
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 7; ++d)

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -35,7 +35,7 @@ void init_search_tables(void)
 {
     // Compute the LMR base values.
     for (int i = 1; i < 256; ++i)
-        Reductions[i] = (int)(log(i) * 24.25 + 4.70);
+        Reductions[i] = (int)(log(i) * 22.70 + 8.70);
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 7; ++d)
@@ -47,7 +47,7 @@ void init_search_tables(void)
 
 int lmr_base_value(int depth, int movecount, bool improving)
 {
-    return (-945 + Reductions[depth] * Reductions[movecount] + !improving * 616) / 1024;
+    return (-682 + Reductions[depth] * Reductions[movecount] + !improving * 417) / 1024;
 }
 
 void init_searchstack(Searchstack *ss)

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -35,7 +35,7 @@ void init_search_tables(void)
 {
     // Compute the LMR base values.
     for (int i = 1; i < 256; ++i)
-        Reductions[i] = (int)(log(i) * 19.55 + 4.85);
+        Reductions[i] = (int)(log(i) * 24.25 + 4.70);
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 7; ++d)
@@ -47,7 +47,7 @@ void init_search_tables(void)
 
 int lmr_base_value(int depth, int movecount, bool improving)
 {
-    return (-391 + Reductions[depth] * Reductions[movecount] + !improving * 642) / 1024;
+    return (-945 + Reductions[depth] * Reductions[movecount] + !improving * 616) / 1024;
 }
 
 void init_searchstack(Searchstack *ss)

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.32"
+#define UCI_VERSION "v34.33"
 
 // clang-format off
 


### PR DESCRIPTION
Tuning done with [chess-tuning-tools](https://chess-tuning-tools.readthedocs.io/en/latest/) at 5+0.05, 50 rounds, 64 iterations.

Passed STC:

```
ELO   | 2.49 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 48352 W: 9643 L: 9296 D: 29413
```
http://chess.grantnet.us/test/33417/

Passed LTC:

```
ELO   | 3.54 +- 2.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 17648 W: 2524 L: 2344 D: 12780
```
http://chess.grantnet.us/test/33423/

Bench: 6,400,034