### PR TITLE
Prevent search explosions

### DIFF
--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -76,6 +76,7 @@ typedef struct worker_s
     PawnEntry *pawnTable;
 
     int seldepth;
+    int rootDepth;
     int verifPlies;
     _Atomic uint64_t nodes;
 

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -223,6 +223,7 @@ void worker_search(worker_t *worker)
             // Reset the seldepth value after each depth increment, and for each
             // PV line.
             worker->seldepth = 0;
+            worker->rootDepth = iterDepth + 1;
 
             score_t alpha, beta, delta;
             int depth = iterDepth;
@@ -571,7 +572,7 @@ __main_loop:
         bool givesCheck = move_gives_check(board, currmove);
         int histScore = isQuiet ? get_history_score(board, worker, ss, currmove) : 0;
 
-        if (!rootNode)
+        if (!rootNode && ss->plies < worker->rootDepth * 2)
         {
             // Singular Extensions. For high-depth nodes, if the TT entry
             // suggests that the TT move is really good, we check if there are

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -572,13 +572,14 @@ __main_loop:
         bool givesCheck = move_gives_check(board, currmove);
         int histScore = isQuiet ? get_history_score(board, worker, ss, currmove) : 0;
 
-        if (!rootNode && ss->plies < worker->rootDepth * 2)
+        if (!rootNode && ss->plies + 2 * ss->doubleExtensions < 3 * worker->rootDepth)
         {
             // Singular Extensions. For high-depth nodes, if the TT entry
             // suggests that the TT move is really good, we check if there are
             // other moves which maintain the score close to the TT score. If
             // that's not the case, we consider the TT move to be singular, and
-            // we extend non-LMR searches by one ply.
+            // we extend non-LMR searches by one or two lies, depending on the 
+            // margin that the singular search failed low.
             if (depth >= 7 && currmove == ttMove && !ss->excludedMove && (ttBound & LOWER_BOUND)
                 && abs(ttScore) < VICTORY && ttDepth >= depth - 2)
             {

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.33"
+#define UCI_VERSION "v34.34"
 
 // clang-format off
 


### PR DESCRIPTION
Cap the number of singular extensions we can do based on ply and root depth in order to prevent search getting stuck. This also improves the comment for singular extensions to include double extensions.

Passed STC:
```
ELO   | 1.83 +- 3.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 15976 W: 3151 L: 3067 D: 9758
```
http://chess.grantnet.us/test/33442/

Passed LTC (rebased):
```
ELO   | 1.17 +- 2.42 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 21976 W: 3087 L: 3013 D: 15876
```
http://chess.grantnet.us/test/33446/

Bench: 6,400,034