### PR TITLE
Do more singular extensions

### DIFF
--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -76,6 +76,7 @@ typedef struct worker_s
     PawnEntry *pawnTable;
 
     int seldepth;
+    int rootDepth;
     int verifPlies;
     _Atomic uint64_t nodes;
 

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -223,6 +223,7 @@ void worker_search(worker_t *worker)
             // Reset the seldepth value after each depth increment, and for each
             // PV line.
             worker->seldepth = 0;
+            worker->rootDepth = iterDepth + 1;
 
             score_t alpha, beta, delta;
             int depth = iterDepth;
@@ -571,7 +572,7 @@ __main_loop:
         bool givesCheck = move_gives_check(board, currmove);
         int histScore = isQuiet ? get_history_score(board, worker, ss, currmove) : 0;
 
-        if (!rootNode)
+        if (!rootNode && ss->plies < worker->rootDepth * 2)
         {
             // Singular Extensions. For high-depth nodes, if the TT entry
             // suggests that the TT move is really good, we check if there are

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -572,13 +572,14 @@ __main_loop:
         bool givesCheck = move_gives_check(board, currmove);
         int histScore = isQuiet ? get_history_score(board, worker, ss, currmove) : 0;
 
-        if (!rootNode && ss->plies < worker->rootDepth * 2)
+        if (!rootNode && ss->plies + 2 * ss->doubleExtensions < 3 * worker->rootDepth)
         {
             // Singular Extensions. For high-depth nodes, if the TT entry
             // suggests that the TT move is really good, we check if there are
             // other moves which maintain the score close to the TT score. If
             // that's not the case, we consider the TT move to be singular, and
-            // we extend non-LMR searches by one ply.
+            // we extend non-LMR searches by one or two lies, depending on the 
+            // margin that the singular search failed low.
             if (depth >= 7 && currmove == ttMove && !ss->excludedMove && (ttBound & LOWER_BOUND)
                 && abs(ttScore) < VICTORY && ttDepth >= depth - 2)
             {

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -572,7 +572,7 @@ __main_loop:
         bool givesCheck = move_gives_check(board, currmove);
         int histScore = isQuiet ? get_history_score(board, worker, ss, currmove) : 0;
 
-        if (!rootNode && ss->plies + 2 * ss->doubleExtensions < 3 * worker->rootDepth)
+        if (!rootNode && ss->plies < 2 * worker->rootDepth && 2 * ss->doubleExtensions < worker->rootDepth)
         {
             // Singular Extensions. For high-depth nodes, if the TT entry
             // suggests that the TT move is really good, we check if there are

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -596,7 +596,7 @@ __main_loop:
                 // move.
                 if (singularScore < singularBeta)
                 {
-                    if (!pvNode && singularBeta - singularScore > 24 && ss->doubleExtensions <= 5)
+                    if (!pvNode && singularBeta - singularScore > 20 && ss->doubleExtensions <= 11)
                     {
                         extension = 2;
                         ss->doubleExtensions++;

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -581,7 +581,7 @@ __main_loop:
             // we extend non-LMR searches by one or two lies, depending on the 
             // margin that the singular search failed low.
             if (depth >= 7 && currmove == ttMove && !ss->excludedMove && (ttBound & LOWER_BOUND)
-                && abs(ttScore) < VICTORY && ttDepth >= depth - 2)
+                && abs(ttScore) < VICTORY && ttDepth >= depth - 3)
             {
                 score_t singularBeta = ttScore - 3 * depth / 4;
                 int singularDepth = depth / 2;
@@ -596,7 +596,7 @@ __main_loop:
                 // move.
                 if (singularScore < singularBeta)
                 {
-                    if (!pvNode && singularBeta - singularScore > 20 && ss->doubleExtensions <= 11)
+                    if (!pvNode && singularBeta - singularScore > 20 && ss->doubleExtensions <= 7)
                     {
                         extension = 2;
                         ss->doubleExtensions++;

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.33"
+#define UCI_VERSION "v34.34"
 
 // clang-format off
 


### PR DESCRIPTION
Do more singular and double extensions, but to a limit.
Also improves SE comment to include double extensions.

Passed LTC:
```
ELO   | 6.27 +- 4.02 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 8032 W: 1200 L: 1055 D: 5777
```
http://chess.grantnet.us/test/33501/

Bench: 7,239,880