### PR TITLE
Do SEE-based futility pruning in qsearch

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -572,13 +572,14 @@ __main_loop:
         bool givesCheck = move_gives_check(board, currmove);
         int histScore = isQuiet ? get_history_score(board, worker, ss, currmove) : 0;
 
-        if (!rootNode && ss->plies < 2 * worker->rootDepth && 2 * ss->doubleExtensions < worker->rootDepth)
+        if (!rootNode && ss->plies < 2 * worker->rootDepth
+            && 2 * ss->doubleExtensions < worker->rootDepth)
         {
             // Singular Extensions. For high-depth nodes, if the TT entry
             // suggests that the TT move is really good, we check if there are
             // other moves which maintain the score close to the TT score. If
             // that's not the case, we consider the TT move to be singular, and
-            // we extend non-LMR searches by one or two lies, depending on the 
+            // we extend non-LMR searches by one or two lies, depending on the
             // margin that the singular search failed low.
             if (depth >= 7 && currmove == ttMove && !ss->excludedMove && (ttBound & LOWER_BOUND)
                 && abs(ttScore) < VICTORY && ttDepth >= depth - 3)

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -883,6 +883,9 @@ score_t qsearch(bool pvNode, Board *board, score_t alpha, score_t beta, Searchst
 
             // Check if the move is unlikely to improve alpha.
             if (delta < alpha) continue;
+
+            // If static eval is far below alpha, only search moves that win material.
+            if (futilityBase < alpha && !see_greater_than(board, currmove, 1)) continue;
         }
 
         // Save the piece history for the current move so that sub-nodes can use

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.34"
+#define UCI_VERSION "v34.35"
 
 // clang-format off
 


### PR DESCRIPTION
Passed STC:
ELO   | 2.86 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 33432 W: 6459 L: 6184 D: 20789
http://chess.grantnet.us/test/33604/

Passed LTC:
ELO   | 5.34 +- 3.55 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9824 W: 1394 L: 1243 D: 7187
http://chess.grantnet.us/test/33613/

Bench: 6,992,062