### PR TITLE
Extend continuation history to 4 plies before

### DIFF
--- a/src/include/search.h
+++ b/src/include/search.h
@@ -40,7 +40,7 @@ extern int Pruning[2][7];
 
 enum
 {
-    MAX_PLIES = 240
+    MAX_PLIES = 238
 };
 
 // Initializes the search tables.

--- a/src/sources/history.c
+++ b/src/sources/history.c
@@ -28,6 +28,7 @@ void update_cont_histories(Searchstack *ss, int depth, piece_t piece, square_t t
 
     if ((ss - 1)->pieceHistory != NULL) add_pc_history(*(ss - 1)->pieceHistory, piece, to, bonus);
     if ((ss - 2)->pieceHistory != NULL) add_pc_history(*(ss - 2)->pieceHistory, piece, to, bonus);
+    if ((ss - 4)->pieceHistory != NULL) add_pc_history(*(ss - 4)->pieceHistory, piece, to, bonus);
 }
 
 void update_quiet_history(const Board *board, int depth, move_t bestmove, const move_t quiets[64],

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -53,7 +53,7 @@ void init_searchstack(Searchstack *ss)
 {
     memset(ss, 0, sizeof(Searchstack) * 256);
 
-    for (int i = 0; i < 256; ++i) (ss + i)->plies = i - 2;
+    for (int i = 0; i < 256; ++i) (ss + i)->plies = i - 4;
 }
 
 int get_history_score(
@@ -64,8 +64,12 @@ int get_history_score(
 
     if ((ss - 1)->pieceHistory != NULL)
         history += get_pc_history_score(*(ss - 1)->pieceHistory, movedPiece, to_sq(move));
+
     if ((ss - 2)->pieceHistory != NULL)
         history += get_pc_history_score(*(ss - 2)->pieceHistory, movedPiece, to_sq(move));
+
+    if ((ss - 4)->pieceHistory != NULL)
+        history += get_pc_history_score(*(ss - 4)->pieceHistory, movedPiece, to_sq(move));
 
     return history;
 }
@@ -245,7 +249,7 @@ void worker_search(worker_t *worker)
             }
 
 __retry:
-            search(true, board, depth + 1, alpha, beta, &sstack[2], false);
+            search(true, board, depth + 1, alpha, beta, &sstack[4], false);
 
             // Catch search aborting.
             hasSearchAborted = SearchWorkerPool.stop;

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.35"
+#define UCI_VERSION "v34.36"
 
 // clang-format off
 


### PR DESCRIPTION
Passed STC:
```
ELO   | 13.09 +- 6.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3824 W: 792 L: 648 D: 2384
```
http://chess.grantnet.us/test/33761/

Passed LTC:
```
ELO   | 8.75 +- 4.81 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5480 W: 819 L: 681 D: 3980
```
http://chess.grantnet.us/test/33771/

Bench: 7,293,044