### PR TITLE
Add Continuation History

### DIFF
--- a/src/include/search.h
+++ b/src/include/search.h
@@ -35,9 +35,6 @@ typedef struct _Searchstack
     piece_history_t *pieceHistory;
 } Searchstack;
 
-// Global for Late Move Pruning
-extern int Pruning[2][7];
-
 enum
 {
     MAX_PLIES = 238

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -165,6 +165,7 @@ void main_worker_search(worker_t *worker)
         // node counter, time manager, workers' board and threads, and TT reset.
         tt_clear();
         wpool_new_search(&SearchWorkerPool);
+        init_search_tables();
         timeman_init(board, &SearchTimeman, &UciSearchParams, chess_clock());
 
         if (UciSearchParams.depth == 0) UciSearchParams.depth = MAX_PLIES;

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.36"
+#define UCI_VERSION "v34.37"
 
 // clang-format off
 

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -616,6 +616,18 @@ void uci_loop(int argc, char **argv)
 
     uci_position("startpos");
 
+    TUNE_DOUBLE(LMP_IB, -5, 5);
+    TUNE_DOUBLE(LMP_IK, 1, 5);
+    TUNE_DOUBLE(LMP_IP, 0, 3);
+    TUNE_DOUBLE(LMP_NB, -5, 5);
+    TUNE_DOUBLE(LMP_NK, 1, 5);
+    TUNE_DOUBLE(LMP_NP, 0, 3);
+
+    TUNE_LONG(LMP_D, 0, 15);
+    TUNE_LONG(CHP_D, 0, 10);
+    TUNE_LONG(CHP_K, -8000, -500);
+    TUNE_LONG(CHP_B, -2000, 2000);
+
     if (argc > 1)
         for (int i = 1; i < argc; ++i) execute_uci_cmd(argv[i]);
     else

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -616,18 +616,6 @@ void uci_loop(int argc, char **argv)
 
     uci_position("startpos");
 
-    TUNE_DOUBLE(LMP_IB, -5, 5);
-    TUNE_DOUBLE(LMP_IK, 1, 5);
-    TUNE_DOUBLE(LMP_IP, 0, 3);
-    TUNE_DOUBLE(LMP_NB, -5, 5);
-    TUNE_DOUBLE(LMP_NK, 1, 5);
-    TUNE_DOUBLE(LMP_NP, 0, 3);
-
-    TUNE_LONG(LMP_D, 0, 15);
-    TUNE_LONG(CHP_D, 0, 10);
-    TUNE_LONG(CHP_K, -8000, -500);
-    TUNE_LONG(CHP_B, -2000, 2000);
-
     if (argc > 1)
         for (int i = 1; i < argc; ++i) execute_uci_cmd(argv[i]);
     else


### PR DESCRIPTION
Initial tune of values along with a retune of LMR using SPSA on a local OpenBench instance.
Time control 8+0.08, 750 iterations.

Passed STC:

```
ELO   | 2.89 +- 2.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 31848 W: 6062 L: 5797 D: 19989
```
http://chess.grantnet.us/test/33939/

Passed LTC:

```
ELO   | 3.24 +- 2.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 20168 W: 2871 L: 2683 D: 14614
```
http://chess.grantnet.us/test/33946/

Bench: 6,442,761
