### PR TITLE
Add Probcut

### DIFF
--- a/src/include/movepick.h
+++ b/src/include/movepick.h
@@ -62,6 +62,6 @@ void movepicker_init(Movepicker *mp, bool inQsearch, const Board *board, const w
     move_t ttMove, Searchstack *ss);
 
 // Returns the next move in the move picker, with the option to skip quiet moves.
-move_t movepicker_next_move(Movepicker *mp, bool skipQuiets);
+move_t movepicker_next_move(Movepicker *mp, bool skipQuiets, int see_threshold);
 
 #endif

--- a/src/sources/movepick.c
+++ b/src/sources/movepick.c
@@ -139,7 +139,7 @@ static void score_evasions(Movepicker *mp, ExtendedMove *begin, ExtendedMove *en
     }
 }
 
-move_t movepicker_next_move(Movepicker *mp, bool skipQuiets)
+move_t movepicker_next_move(Movepicker *mp, bool skipQuiets, int see_threshold)
 {
 __top:
 
@@ -165,7 +165,7 @@ __top:
                 place_top_move(mp->cur, mp->list.last);
 
                 // Only select moves with a positive SEE for this stage.
-                if (mp->cur->move != mp->ttMove && see_greater_than(mp->board, mp->cur->move, 0))
+                if (mp->cur->move != mp->ttMove && see_greater_than(mp->board, mp->cur->move, see_threshold))
                     return (mp->cur++)->move;
 
                 // Place bad captures further in the list so that we can use

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -56,8 +56,7 @@ void init_searchstack(Searchstack *ss)
     for (int i = 0; i < 256; ++i) (ss + i)->plies = i - 4;
 }
 
-int get_conthist_score(
-    const Board *board, const Searchstack *ss, move_t move)
+int get_conthist_score(const Board *board, const Searchstack *ss, move_t move)
 {
     const piece_t movedPiece = piece_on(board, from_sq(move));
     const square_t to = to_sq(move);
@@ -81,7 +80,7 @@ int get_history_score(
     const piece_t movedPiece = piece_on(board, from_sq(move));
 
     return get_bf_history_score(worker->bfHistory, movedPiece, move)
-        + get_conthist_score(board, ss, move);
+           + get_conthist_score(board, ss, move);
 }
 
 uint64_t perft(Board *board, unsigned int depth)
@@ -410,6 +409,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     hashkey_t key = board->stack->boardKey ^ ((hashkey_t)ss->excludedMove << 16);
     TT_Entry *entry = tt_probe(key, &found);
     score_t eval;
+    score_t probCutBeta;
 
     if (found)
     {
@@ -517,6 +517,48 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
         }
     }
 
+    // Probcut
+    probCutBeta = beta + 256;
+    if (depth >= 4 && abs(beta) < VICTORY
+        && !(found && ttDepth >= depth - 3 && ttScore < probCutBeta))
+    {
+        movepicker_init(&mp, true, board, worker,
+            ttMove && see_greater_than(board, ttMove, probCutBeta - ss->staticEval) ? ttMove
+                                                                                    : NO_MOVE,
+            ss);
+        move_t currmove;
+        while (
+            (currmove = movepicker_next_move(&mp, false, probCutBeta - ss->staticEval)) != NO_MOVE)
+        {
+            if (mp.stage == PICK_BAD_INSTABLE) break;
+
+            if (!move_is_legal(board, currmove) || currmove == ss->excludedMove) continue;
+
+            ss->currentMove = currmove;
+            ss->pieceHistory =
+                &worker->ctHistory[piece_on(board, from_sq(currmove))][to_sq(currmove)];
+
+            Boardstack stack;
+            bool givesCheck = move_gives_check(board, currmove);
+            do_move_gc(board, currmove, &stack, givesCheck);
+
+            score_t probCutScore = -qsearch(false, board, -probCutBeta, -probCutBeta + 1, ss + 1);
+
+            if (probCutScore >= probCutBeta)
+                probCutScore = -search(
+                    false, board, depth - 4, -probCutBeta, -probCutBeta + 1, ss + 1, !cutNode);
+
+            undo_move(board, currmove);
+
+            if (probCutScore >= probCutBeta)
+            {
+                tt_save(entry, key, score_to_tt(probCutScore, ss->plies), ss->staticEval, depth - 3,
+                    LOWER_BOUND, currmove);
+                return probCutScore;
+            }
+        }
+    }
+
     // Reduce depth if the node is absent from TT.
     if (!rootNode && !found && depth >= 4) --depth;
 
@@ -532,7 +574,7 @@ __main_loop:
     int ccount = 0;
     bool skipQuiets = false;
 
-    while ((currmove = movepicker_next_move(&mp, skipQuiets)) != NO_MOVE)
+    while ((currmove = movepicker_next_move(&mp, skipQuiets, 0)) != NO_MOVE)
     {
         if (rootNode)
         {
@@ -882,7 +924,7 @@ score_t qsearch(bool pvNode, Board *board, score_t alpha, score_t beta, Searchst
     const bool canFutilityPrune = (!inCheck && popcount(board->piecetypeBB[ALL_PIECES]) > 6);
     const score_t futilityBase = bestScore + 120;
 
-    while ((currmove = movepicker_next_move(&mp, false)) != NO_MOVE)
+    while ((currmove = movepicker_next_move(&mp, false, 0)) != NO_MOVE)
     {
         // Only analyse good capture moves.
         if (bestScore > -MATE_FOUND && mp.stage == PICK_BAD_INSTABLE) break;

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -517,7 +517,8 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
         }
     }
 
-    // Probcut
+    // Probcut. If we have a good enough capture (or queen promotion) and a reduced search returns a
+    // value much above beta, we can (almost) safely prune the previous move.
     probCutBeta = beta + 256;
     if (depth >= 4 && abs(beta) < VICTORY
         && !(found && ttDepth >= depth - 3 && ttScore < probCutBeta))

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.37"
+#define UCI_VERSION "v34.38"
 
 // clang-format off
 


### PR DESCRIPTION
Passed STC:
ELO   | 5.59 +- 3.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 11184 W: 2196 L: 2016 D: 6972
http://chess.grantnet.us/test/33971/

Passed LTC:
ELO   | 2.39 +- 1.92 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 34592 W: 4870 L: 4632 D: 25090
http://chess.grantnet.us/test/33973/

Bench: 6,694,634