### PR TITLE
Make probcut more aggressive

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -519,7 +519,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
 
     // Probcut. If we have a good enough capture (or queen promotion) and a reduced search returns a
     // value much above beta, we can (almost) safely prune the previous move.
-    probCutBeta = beta + 256;
+    probCutBeta = beta + 128;
     if (depth >= 4 && abs(beta) < VICTORY
         && !(found && ttDepth >= depth - 3 && ttScore < probCutBeta))
     {

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -517,7 +517,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
         }
     }
 
-    // Probcut. If we have a good enough capture (or queen promotion) and a reduced search returns a
+    // Probcut. If we have a good enough capture (or promotion) and a reduced search returns a
     // value much above beta, we can (almost) safely prune the previous move.
     probCutBeta = beta + 128;
     if (depth >= 4 && abs(beta) < VICTORY

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v34.38"
+#define UCI_VERSION "v34.39"
 
 // clang-format off
 


### PR DESCRIPTION
Passed LTC:
ELO   | 3.75 +- 2.77 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 16312 W: 2302 L: 2126 D: 11884
http://chess.grantnet.us/test/33977/

Bench: 6,037,006