### PR TITLE
Quality of life improvements for v35

### DIFF
--- a/src/include/bitboard.h
+++ b/src/include/bitboard.h
@@ -29,33 +29,34 @@
 
 typedef uint64_t bitboard_t;
 
-// Defines for file bitboard masks.
-#define FILE_A_BB 0x0101010101010101ull
-#define FILE_B_BB 0x0202020202020202ull
-#define FILE_C_BB 0x0404040404040404ull
-#define FILE_D_BB 0x0808080808080808ull
-#define FILE_E_BB 0x1010101010101010ull
-#define FILE_F_BB 0x2020202020202020ull
-#define FILE_G_BB 0x4040404040404040ull
-#define FILE_H_BB 0x8080808080808080ull
+// Constants for file bitboard masks.
+static const bitboard_t FILE_A_BB = 0x0101010101010101ul;
+static const bitboard_t FILE_B_BB = 0x0202020202020202ul;
+static const bitboard_t FILE_C_BB = 0x0404040404040404ul;
+static const bitboard_t FILE_D_BB = 0x0808080808080808ul;
+static const bitboard_t FILE_E_BB = 0x1010101010101010ul;
+static const bitboard_t FILE_F_BB = 0x2020202020202020ul;
+static const bitboard_t FILE_G_BB = 0x4040404040404040ul;
+static const bitboard_t FILE_H_BB = 0x8080808080808080ul;
 
-// Defines for rank bitboard masks.
-#define RANK_1_BB 0x00000000000000FFull
-#define RANK_2_BB 0x000000000000FF00ull
-#define RANK_3_BB 0x0000000000FF0000ull
-#define RANK_4_BB 0x00000000FF000000ull
-#define RANK_5_BB 0x000000FF00000000ull
-#define RANK_6_BB 0x0000FF0000000000ull
-#define RANK_7_BB 0x00FF000000000000ull
-#define RANK_8_BB 0xFF00000000000000ull
+// Constants for rank bitboard masks.
+static const bitboard_t RANK_1_BB = 0x00000000000000FFul;
+static const bitboard_t RANK_2_BB = 0x000000000000FF00ul;
+static const bitboard_t RANK_3_BB = 0x0000000000FF0000ul;
+static const bitboard_t RANK_4_BB = 0x00000000FF000000ul;
+static const bitboard_t RANK_5_BB = 0x000000FF00000000ul;
+static const bitboard_t RANK_6_BB = 0x0000FF0000000000ul;
+static const bitboard_t RANK_7_BB = 0x00FF000000000000ul;
+static const bitboard_t RANK_8_BB = 0xFF00000000000000ul;
 
-// Defines for miscellaneous bitboard masks.
-#define FULL_BB 0xFFFFFFFFFFFFFFFFull
-#define DARK_SQUARES 0xAA55AA55AA55AA55ull
-#define KINGSIDE_BB 0xF0F0F0F0F0F0F0F0ull
-#define QUEENSIDE_BB 0x0F0F0F0F0F0F0F0Full
-#define CENTER_FILES_BB 0x3C3C3C3C3C3C3C3Cull
-#define CENTER_BB 0x0000001818000000ull
+// Constants for miscellaneous bitboard masks.
+static const bitboard_t ALL_BB = 0xFFFFFFFFFFFFFFFFul;
+static const bitboard_t DSQ_BB = 0xAA55AA55AA55AA55ul;
+static const bitboard_t LSQ_BB = ~DSQ_BB;
+static const bitboard_t KINGSIDE_BB = 0xF0F0F0F0F0F0F0F0ul;
+static const bitboard_t QUEENSIDE_BB = 0x0F0F0F0F0F0F0F0Ful;
+static const bitboard_t CENTER_FILES_BB = 0x3C3C3C3C3C3C3C3Cul;
+static const bitboard_t CENTER_BB = 0x0000001818000000ul;
 
 // Bitboards of all squares on the line between two squares.
 extern bitboard_t LineBB[SQUARE_NB][SQUARE_NB];
@@ -147,8 +148,7 @@ INLINED bitboard_t sq_rank_bb(square_t square) { return rank_bb(sq_rank(square))
 // Returns the bitboard of all squares between two squares (both squares excluded).
 INLINED bitboard_t between_bb(square_t sq1, square_t sq2)
 {
-    return LineBB[sq1][sq2]
-           & ((FULL_BB << (sq1 + (sq1 < sq2))) ^ (FULL_BB << (sq2 + !(sq1 < sq2))));
+    return LineBB[sq1][sq2] & ((ALL_BB << (sq1 + (sq1 < sq2))) ^ (ALL_BB << (sq2 + !(sq1 < sq2))));
 }
 
 // Checks if all three squares share the same file, rank or diagonal.

--- a/src/include/hashkey.h
+++ b/src/include/hashkey.h
@@ -48,7 +48,7 @@ extern hashkey_t ZobristEnPassant[FILE_NB];
 extern hashkey_t ZobristCastling[CASTLING_NB];
 
 // Global value for Zobrist STM hash
-extern hashkey_t ZobristBlackToMove;
+extern hashkey_t ZobristSideToMove;
 
 void zobrist_init(void);
 

--- a/src/include/movelist.h
+++ b/src/include/movelist.h
@@ -41,35 +41,36 @@ typedef struct _MoveList
 extern Movelist UciSearchMoves;
 
 // Generates all legal moves for the given board and stores them in the given movelist.
-ExtendedMove *generate_all(ExtendedMove *movelist, const Board *board);
+ExtendedMove *generate_all(ExtendedMove *restrict movelist, const Board *restrict board);
 
 // Generates all pseudo-legal moves for the given board (only for not in-check positions) and stores
 // them in the given movelist.
-ExtendedMove *generate_classic(ExtendedMove *movelist, const Board *board);
+ExtendedMove *generate_classic(ExtendedMove *restrict movelist, const Board *restrict board);
 
 // Generates all pseudo-legal moves for the given board (only for in-check positions) and stores
 // them in the given movelist.
-ExtendedMove *generate_evasions(ExtendedMove *movelist, const Board *board);
+ExtendedMove *generate_evasions(ExtendedMove *restrict movelist, const Board *restrict board);
 
 // Generates all pseudo-legal captures/queen promotions for the given board and stores them in the
 // given movelist.
-ExtendedMove *generate_captures(ExtendedMove *movelist, const Board *board, bool inQsearch);
+ExtendedMove *generate_captures(
+    ExtendedMove *restrict movelist, const Board *restrict board, bool inQsearch);
 
 // Generates all pseudo-legal non-captures/non-queen promotions for the given board and stores them
 // in the given movelist.
-ExtendedMove *generate_quiet(ExtendedMove *movelist, const Board *board);
+ExtendedMove *generate_quiet(ExtendedMove *restrict movelist, const Board *restrict board);
 
 // Places the move with the highest score in the first position of the movelist.
 void place_top_move(ExtendedMove *begin, ExtendedMove *end);
 
 // Generates all legal moves for the given board.
-INLINED void list_all(Movelist *movelist, const Board *board)
+INLINED void list_all(Movelist *restrict movelist, const Board *restrict board)
 {
     movelist->last = generate_all(movelist->moves, board);
 }
 
 // Generates all pseudo-legal moves for the given board.
-INLINED void list_pseudo(Movelist *movelist, const Board *board)
+INLINED void list_pseudo(Movelist *restrict movelist, const Board *restrict board)
 {
     movelist->last = board->stack->checkers ? generate_evasions(movelist->moves, board)
                                             : generate_classic(movelist->moves, board);

--- a/src/include/search.h
+++ b/src/include/search.h
@@ -35,11 +35,6 @@ typedef struct _Searchstack
     piece_history_t *pieceHistory;
 } Searchstack;
 
-enum
-{
-    MAX_PLIES = 238
-};
-
 // Initializes the search tables.
 void init_search_tables(void);
 

--- a/src/include/timeman.h
+++ b/src/include/timeman.h
@@ -102,14 +102,14 @@ void check_time(void);
 // Checks if we can safely stop the search.
 INLINED bool timeman_can_stop_search(Timeman *tm, clock_t cur)
 {
-    if (tm->pondering && SearchWorkerPool.ponder) return false;
+    if (tm->pondering && wpool_is_pondering(&SearchWorkerPool)) return false;
     return tm->mode != NoTimeman && cur >= tm->start + tm->optimalTime;
 }
 
 // Checks if we must stop the search.
 INLINED bool timeman_must_stop_search(Timeman *tm, clock_t cur)
 {
-    if (tm->pondering && SearchWorkerPool.ponder) return false;
+    if (tm->pondering && wpool_is_pondering(&SearchWorkerPool)) return false;
     return tm->mode != NoTimeman && cur >= tm->start + tm->maximalTime;
 }
 

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -257,10 +257,15 @@ typedef int16_t phase_t;
 
 enum
 {
+    MAX_PLIES = 238
+};
+
+enum
+{
     DRAW = 0,
     VICTORY = 10000,
-    MATE_FOUND = 31760,
     MATE = 32000,
+    MATE_FOUND = MATE - MAX_PLIES,
     INF_SCORE = 32001,
     NO_SCORE = 32002
 };

--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -113,8 +113,8 @@ typedef struct _WorkerPool
     size_t size;
     int checks;
 
-    _Atomic bool ponder;
-    _Atomic bool stop;
+    atomic_bool ponder;
+    atomic_bool stop;
 
     Worker **workerList;
 } WorkerPool;
@@ -122,6 +122,26 @@ typedef struct _WorkerPool
 extern WorkerPool SearchWorkerPool;
 
 INLINED Worker *wpool_main_worker(WorkerPool *wpool) { return wpool->workerList[0]; }
+
+INLINED void wpool_ponderhit(WorkerPool *wpool)
+{
+    atomic_store_explicit(&wpool->ponder, false, memory_order_relaxed);
+}
+
+INLINED bool wpool_is_pondering(const WorkerPool *wpool)
+{
+    return atomic_load_explicit(&wpool->ponder, memory_order_relaxed);
+}
+
+INLINED void wpool_stop(WorkerPool *wpool)
+{
+    atomic_store_explicit(&wpool->stop, true, memory_order_relaxed);
+}
+
+INLINED bool wpool_is_stopped(const WorkerPool *wpool)
+{
+    return atomic_load_explicit(&wpool->stop, memory_order_relaxed);
+}
 
 void wpool_init(WorkerPool *wpool, size_t threads);
 void wpool_new_search(WorkerPool *wpool);

--- a/src/sources/bench.c
+++ b/src/sources/bench.c
@@ -23,80 +23,87 @@
 #include <string.h>
 #include <unistd.h>
 
+// List of positions used during bench
+const char *BenchFENs[] = {"r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14",
+    "4rrk1/2p1b1p1/p1p3q1/4p3/2P2n1p/1P1NR2P/PB3PP1/3R1QK1 b - - 2 24",
+    "r3qbrk/6p1/2b2pPp/p3pP1Q/PpPpP2P/3P1B2/2PB3K/R5R1 w - - 16 42",
+    "6k1/1R3p2/6p1/2Bp3p/3P2q1/P7/1P2rQ1K/5R2 b - - 4 44",
+    "8/8/1p2k1p1/3p3p/1p1P1P1P/1P2PK2/8/8 w - - 3 54",
+    "7r/2p3k1/1p1p1qp1/1P1Bp3/p1P2r1P/P7/4R3/Q4RK1 w - - 0 36",
+    "r1bq1rk1/pp2b1pp/n1pp1n2/3P1p2/2P1p3/2N1P2N/PP2BPPP/R1BQ1RK1 b - - 2 10",
+    "3r3k/2r4p/1p1b3q/p4P2/P2Pp3/1B2P3/3BQ1RP/6K1 w - - 3 87",
+    "2r4r/1p4k1/1Pnp4/3Qb1pq/8/4BpPp/5P2/2RR1BK1 w - - 0 42",
+    "4q1bk/6b1/7p/p1p4p/PNPpP2P/KN4P1/3Q4/4R3 b - - 0 37",
+    "2q3r1/1r2pk2/pp3pp1/2pP3p/P1Pb1BbP/1P4Q1/R3NPP1/4R1K1 w - - 2 34",
+    "1r2r2k/1b4q1/pp5p/2pPp1p1/P3Pn2/1P1B1Q1P/2R3P1/4BR1K b - - 1 37",
+    "r3kbbr/pp1n1p1P/3ppnp1/q5N1/1P1pP3/P1N1B3/2P1QP2/R3KB1R b KQkq b3 0 17",
+    "8/6pk/2b1Rp2/3r4/1R1B2PP/P5K1/8/2r5 b - - 16 42",
+    "1r4k1/4ppb1/2n1b1qp/pB4p1/1n1BP1P1/7P/2PNQPK1/3RN3 w - - 8 29",
+    "8/p2B4/PkP5/4p1pK/4Pb1p/5P2/8/8 w - - 29 68",
+    "3r4/ppq1ppkp/4bnp1/2pN4/2P1P3/1P4P1/PQ3PBP/R4K2 b - - 2 20",
+    "5rr1/4n2k/4q2P/P1P2n2/3B1p2/4pP2/2N1P3/1RR1K2Q w - - 1 49",
+    "1r5k/2pq2p1/3p3p/p1pP4/4QP2/PP1R3P/6PK/8 w - - 1 51",
+    "q5k1/5ppp/1r3bn1/1B6/P1N2P2/BQ2P1P1/5K1P/8 b - - 2 34",
+    "r1b2k1r/5n2/p4q2/1ppn1Pp1/3pp1p1/NP2P3/P1PPBK2/1RQN2R1 w - - 0 22",
+    "r1bqk2r/pppp1ppp/5n2/4b3/4P3/P1N5/1PP2PPP/R1BQKB1R w KQkq - 0 5",
+    "r1bqr1k1/pp1p1ppp/2p5/8/3N1Q2/P2BB3/1PP2PPP/R3K2n b Q - 1 12",
+    "r1bq2k1/p4r1p/1pp2pp1/3p4/1P1B3Q/P2B1N2/2P3PP/4R1K1 b - - 2 19",
+    "r4qk1/6r1/1p4p1/2ppBbN1/1p5Q/P7/2P3PP/5RK1 w - - 2 25",
+    "r7/6k1/1p6/2pp1p2/7Q/8/p1P2K1P/8 w - - 0 32",
+    "r3k2r/ppp1pp1p/2nqb1pn/3p4/4P3/2PP4/PP1NBPPP/R2QK1NR w KQkq - 1 5",
+    "3r1rk1/1pp1pn1p/p1n1q1p1/3p4/Q3P3/2P5/PP1NBPPP/4RRK1 w - - 0 12",
+    "5rk1/1pp1pn1p/p3Brp1/8/1n6/5N2/PP3PPP/2R2RK1 w - - 2 20",
+    "8/1p2pk1p/p1p1r1p1/3n4/8/5R2/PP3PPP/4R1K1 b - - 3 27",
+    "8/4pk2/1p1r2p1/p1p4p/Pn5P/3R4/1P3PP1/4RK2 w - - 1 33",
+    "8/5k2/1pnrp1p1/p1p4p/P6P/4R1PK/1P3P2/4R3 b - - 1 38",
+    "8/8/1p1kp1p1/p1pr1n1p/P6P/1R4P1/1P3PK1/1R6 b - - 15 45",
+    "8/8/1p1k2p1/p1prp2p/P2n3P/6P1/1P1R1PK1/4R3 b - - 5 49",
+    "8/8/1p4p1/p1p2k1p/P2npP1P/4K1P1/1P6/3R4 w - - 6 54",
+    "8/8/1p4p1/p1p2k1p/P2n1P1P/4K1P1/1P6/6R1 b - - 6 59",
+    "8/5k2/1p4p1/p1pK3p/P2n1P1P/6P1/1P6/4R3 b - - 14 63",
+    "8/1R6/1p1K1kp1/p6p/P1p2P1P/6P1/1Pn5/8 w - - 0 67",
+    "1rb1rn1k/p3q1bp/2p3p1/2p1p3/2P1P2N/PP1RQNP1/1B3P2/4R1K1 b - - 4 23",
+    "4rrk1/pp1n1pp1/q5p1/P1pP4/2n3P1/7P/1P3PB1/R1BQ1RK1 w - - 3 22",
+    "r2qr1k1/pb1nbppp/1pn1p3/2ppP3/3P4/2PB1NN1/PP3PPP/R1BQR1K1 w - - 4 12",
+    "2r2k2/8/4P1R1/1p6/8/P4K1N/7b/2B5 b - - 0 55", "6k1/5pp1/8/2bKP2P/2P5/p4PNb/B7/8 b - - 1 44",
+    "2rqr1k1/1p3p1p/p2p2p1/P1nPb3/2B1P3/5P2/1PQ2NPP/R1R4K w - - 3 25",
+    "r1b2rk1/p1q1ppbp/6p1/2Q5/8/4BP2/PPP3PP/2KR1B1R b - - 2 14",
+    "6r1/5k2/p1b1r2p/1pB1p1p1/1Pp3PP/2P1R1K1/2P2P2/3R4 w - - 1 36",
+    "rnbqkb1r/pppppppp/5n2/8/2PP4/8/PP2PPPP/RNBQKBNR b KQkq c3 0 2",
+    "2rr2k1/1p4bp/p1q1p1p1/4Pp1n/2PB4/1PN3P1/P3Q2P/2RR2K1 w - f6 0 20",
+    "3br1k1/p1pn3p/1p3n2/5pNq/2P1p3/1PN3PP/P2Q1PB1/4R1K1 w - - 0 23",
+    "2r2b2/5p2/5k2/p1r1pP2/P2pB3/1P3P2/K1P3R1/7R w - - 23 93", NULL};
+
 void uci_bench(const char *args)
 {
-    // If bench depth isn't given, use default depth of 13.
-    if (!args || !atoi(args)) args = "13";
+    unsigned long benchDepth = args != NULL ? strtoul(args, NULL, 10) : 0;
+    char goCommand[10];
+    char positionCommand[128];
 
-    // List of positions to search
-    const char *positions[] = {
-        "fen r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14",
-        "fen 4rrk1/2p1b1p1/p1p3q1/4p3/2P2n1p/1P1NR2P/PB3PP1/3R1QK1 b - - 2 24",
-        "fen r3qbrk/6p1/2b2pPp/p3pP1Q/PpPpP2P/3P1B2/2PB3K/R5R1 w - - 16 42",
-        "fen 6k1/1R3p2/6p1/2Bp3p/3P2q1/P7/1P2rQ1K/5R2 b - - 4 44",
-        "fen 8/8/1p2k1p1/3p3p/1p1P1P1P/1P2PK2/8/8 w - - 3 54",
-        "fen 7r/2p3k1/1p1p1qp1/1P1Bp3/p1P2r1P/P7/4R3/Q4RK1 w - - 0 36",
-        "fen r1bq1rk1/pp2b1pp/n1pp1n2/3P1p2/2P1p3/2N1P2N/PP2BPPP/R1BQ1RK1 b - - 2 10",
-        "fen 3r3k/2r4p/1p1b3q/p4P2/P2Pp3/1B2P3/3BQ1RP/6K1 w - - 3 87",
-        "fen 2r4r/1p4k1/1Pnp4/3Qb1pq/8/4BpPp/5P2/2RR1BK1 w - - 0 42",
-        "fen 4q1bk/6b1/7p/p1p4p/PNPpP2P/KN4P1/3Q4/4R3 b - - 0 37",
-        "fen 2q3r1/1r2pk2/pp3pp1/2pP3p/P1Pb1BbP/1P4Q1/R3NPP1/4R1K1 w - - 2 34",
-        "fen 1r2r2k/1b4q1/pp5p/2pPp1p1/P3Pn2/1P1B1Q1P/2R3P1/4BR1K b - - 1 37",
-        "fen r3kbbr/pp1n1p1P/3ppnp1/q5N1/1P1pP3/P1N1B3/2P1QP2/R3KB1R b KQkq b3 0 17",
-        "fen 8/6pk/2b1Rp2/3r4/1R1B2PP/P5K1/8/2r5 b - - 16 42",
-        "fen 1r4k1/4ppb1/2n1b1qp/pB4p1/1n1BP1P1/7P/2PNQPK1/3RN3 w - - 8 29",
-        "fen 8/p2B4/PkP5/4p1pK/4Pb1p/5P2/8/8 w - - 29 68",
-        "fen 3r4/ppq1ppkp/4bnp1/2pN4/2P1P3/1P4P1/PQ3PBP/R4K2 b - - 2 20",
-        "fen 5rr1/4n2k/4q2P/P1P2n2/3B1p2/4pP2/2N1P3/1RR1K2Q w - - 1 49",
-        "fen 1r5k/2pq2p1/3p3p/p1pP4/4QP2/PP1R3P/6PK/8 w - - 1 51",
-        "fen q5k1/5ppp/1r3bn1/1B6/P1N2P2/BQ2P1P1/5K1P/8 b - - 2 34",
-        "fen r1b2k1r/5n2/p4q2/1ppn1Pp1/3pp1p1/NP2P3/P1PPBK2/1RQN2R1 w - - 0 22",
-        "fen r1bqk2r/pppp1ppp/5n2/4b3/4P3/P1N5/1PP2PPP/R1BQKB1R w KQkq - 0 5",
-        "fen r1bqr1k1/pp1p1ppp/2p5/8/3N1Q2/P2BB3/1PP2PPP/R3K2n b Q - 1 12",
-        "fen r1bq2k1/p4r1p/1pp2pp1/3p4/1P1B3Q/P2B1N2/2P3PP/4R1K1 b - - 2 19",
-        "fen r4qk1/6r1/1p4p1/2ppBbN1/1p5Q/P7/2P3PP/5RK1 w - - 2 25",
-        "fen r7/6k1/1p6/2pp1p2/7Q/8/p1P2K1P/8 w - - 0 32",
-        "fen r3k2r/ppp1pp1p/2nqb1pn/3p4/4P3/2PP4/PP1NBPPP/R2QK1NR w KQkq - 1 5",
-        "fen 3r1rk1/1pp1pn1p/p1n1q1p1/3p4/Q3P3/2P5/PP1NBPPP/4RRK1 w - - 0 12",
-        "fen 5rk1/1pp1pn1p/p3Brp1/8/1n6/5N2/PP3PPP/2R2RK1 w - - 2 20",
-        "fen 8/1p2pk1p/p1p1r1p1/3n4/8/5R2/PP3PPP/4R1K1 b - - 3 27",
-        "fen 8/4pk2/1p1r2p1/p1p4p/Pn5P/3R4/1P3PP1/4RK2 w - - 1 33",
-        "fen 8/5k2/1pnrp1p1/p1p4p/P6P/4R1PK/1P3P2/4R3 b - - 1 38",
-        "fen 8/8/1p1kp1p1/p1pr1n1p/P6P/1R4P1/1P3PK1/1R6 b - - 15 45",
-        "fen 8/8/1p1k2p1/p1prp2p/P2n3P/6P1/1P1R1PK1/4R3 b - - 5 49",
-        "fen 8/8/1p4p1/p1p2k1p/P2npP1P/4K1P1/1P6/3R4 w - - 6 54",
-        "fen 8/8/1p4p1/p1p2k1p/P2n1P1P/4K1P1/1P6/6R1 b - - 6 59",
-        "fen 8/5k2/1p4p1/p1pK3p/P2n1P1P/6P1/1P6/4R3 b - - 14 63",
-        "fen 8/1R6/1p1K1kp1/p6p/P1p2P1P/6P1/1Pn5/8 w - - 0 67",
-        "fen 1rb1rn1k/p3q1bp/2p3p1/2p1p3/2P1P2N/PP1RQNP1/1B3P2/4R1K1 b - - 4 23",
-        "fen 4rrk1/pp1n1pp1/q5p1/P1pP4/2n3P1/7P/1P3PB1/R1BQ1RK1 w - - 3 22",
-        "fen r2qr1k1/pb1nbppp/1pn1p3/2ppP3/3P4/2PB1NN1/PP3PPP/R1BQR1K1 w - - 4 12",
-        "fen 2r2k2/8/4P1R1/1p6/8/P4K1N/7b/2B5 b - - 0 55",
-        "fen 6k1/5pp1/8/2bKP2P/2P5/p4PNb/B7/8 b - - 1 44",
-        "fen 2rqr1k1/1p3p1p/p2p2p1/P1nPb3/2B1P3/5P2/1PQ2NPP/R1R4K w - - 3 25",
-        "fen r1b2rk1/p1q1ppbp/6p1/2Q5/8/4BP2/PPP3PP/2KR1B1R b - - 2 14",
-        "fen 6r1/5k2/p1b1r2p/1pB1p1p1/1Pp3PP/2P1R1K1/2P2P2/3R4 w - - 1 36",
-        "fen rnbqkb1r/pppppppp/5n2/8/2PP4/8/PP2PPPP/RNBQKBNR b KQkq c3 0 2",
-        "fen 2rr2k1/1p4bp/p1q1p1p1/4Pp1n/2PB4/1PN3P1/P3Q2P/2RR2K1 w - f6 0 20",
-        "fen 3br1k1/p1pn3p/1p3n2/5pNq/2P1p3/1PN3PP/P2Q1PB1/4R1K1 w - - 0 23",
-        "fen 2r2b2/5p2/5k2/p1r1pP2/P2pB3/1P3P2/K1P3R1/7R w - - 23 93", NULL};
+    // If bench depth is absent or invalid, use a default depth of 13.
+    if (benchDepth == 0 || benchDepth > MAX_PLIES) benchDepth = 13;
+
+    sprintf(goCommand, "depth %lu", benchDepth);
 
     // Initialize the overall clock here.
     clock_t benchTime = chess_clock();
     uint64_t totalNodes = 0;
 
-    for (size_t i = 0; positions[i]; ++i)
+    for (size_t i = 0; BenchFENs[i]; ++i)
     {
-        char buf[4096];
+        strcpy(positionCommand, "fen ");
+        strcat(positionCommand, BenchFENs[i]);
 
-        // Prepare the 'go depth X' string.
-        strcpy(buf, "depth ");
-        strcat(buf, args);
+        const clock_t initTime = chess_clock();
 
         // Reset the overall game state and launch a new search.
         uci_ucinewgame(NULL);
-        uci_position(positions[i]);
-        uci_go(buf);
+        uci_position(positionCommand);
+
+        // Remove the initialization time from the benchmark.
+        benchTime += chess_clock() - initTime;
+
+        uci_go(goCommand);
 
         // Wait for search completion.
         worker_wait_search_end(wpool_main_worker(&SearchWorkerPool));

--- a/src/sources/endgame.c
+++ b/src/sources/endgame.c
@@ -94,7 +94,7 @@ score_t eval_kbnk(const Board *board, color_t winningSide)
     score += 70 - 10 * SquareDistance[losingKsq][winningKsq];
 
     // Don't push the King to the wrong corner.
-    if (piecetype_bb(board, BISHOP) & DARK_SQUARES) losingKsq ^= SQ_A8;
+    if (piecetype_bb(board, BISHOP) & DSQ_BB) losingKsq ^= SQ_A8;
 
     score += abs(sq_file(losingKsq) - sq_rank(losingKsq)) * 100;
 
@@ -259,14 +259,14 @@ score_t eval_kbpsk(const Board *board, color_t winningSide)
     square_t winningBsq = relative_sq(bb_first_sq(piecetype_bb(board, BISHOP)), winningSide);
     square_t losingKsq = relative_sq(get_king_square(board, losingSide), winningSide);
     bitboard_t winningPawns = piecetype_bb(board, PAWN);
-    bitboard_t wrongFile = (square_bb(winningBsq) & DARK_SQUARES) ? FILE_A_BB : FILE_H_BB;
+    bitboard_t wrongFile = (square_bb(winningBsq) & DSQ_BB) ? FILE_A_BB : FILE_H_BB;
 
     if (board->sideToMove == BLACK) score = -score;
 
     // Check for a wrong-colored bishop situation.
     if ((winningPawns & wrongFile) == winningPawns)
     {
-        bitboard_t queeningSquare = (square_bb(winningBsq) & DARK_SQUARES) ? SQ_A8 : SQ_H8;
+        bitboard_t queeningSquare = (square_bb(winningBsq) & DSQ_BB) ? SQ_A8 : SQ_H8;
 
         int queeningDistance = SquareDistance[losingKsq][queeningSquare];
 

--- a/src/sources/evaluate.c
+++ b/src/sources/evaluate.c
@@ -215,7 +215,7 @@ score_t eval_kxk(const Board *board, color_t us)
     bitboard_t bishops = piecetype_bb(board, BISHOP);
 
     if (piecetype_bb(board, QUEEN) || piecetype_bb(board, ROOK) || (knights && bishops)
-        || ((bishops & DARK_SQUARES) && (bishops & ~DARK_SQUARES)) || (popcount(knights) >= 3))
+        || ((bishops & DSQ_BB) && (bishops & LSQ_BB)) || (popcount(knights) >= 3))
         score += VICTORY;
 
     return board->sideToMove == us ? score : -score;
@@ -233,7 +233,7 @@ bool ocb_endgame(const Board *board)
     if (!bbishop || more_than_one(bbishop)) return false;
 
     // Then check that the Bishops are on opposite colored squares.
-    bitboard_t dsqMask = (wbishop | bbishop) & DARK_SQUARES;
+    bitboard_t dsqMask = (wbishop | bbishop) & DSQ_BB;
 
     return !!dsqMask && !more_than_one(dsqMask);
 }
@@ -441,7 +441,7 @@ scorepair_t evaluate_bishops(const Board *board, evaluation_t *eval, color_t us)
         // Give a bonus/penalty based on the number of friendly Pawns which are
         // on same color squares as the Bishop.
         {
-            bitboard_t sqMask = (sqbb & DARK_SQUARES) ? DARK_SQUARES : ~DARK_SQUARES;
+            bitboard_t sqMask = (sqbb & DSQ_BB) ? DSQ_BB : LSQ_BB;
 
             ret += BishopPawnsSameColor[imin(popcount(sqMask & ourPawns), 6)];
             TRACE_ADD(IDX_BISHOP_PAWNS_COLOR + imin(popcount(sqMask & ourPawns), 6), us, 1);

--- a/src/sources/hashkey.c
+++ b/src/sources/hashkey.c
@@ -24,7 +24,7 @@
 hashkey_t ZobristPsq[PIECE_NB][SQUARE_NB];
 hashkey_t ZobristEnPassant[FILE_NB];
 hashkey_t ZobristCastling[CASTLING_NB];
-hashkey_t ZobristBlackToMove;
+hashkey_t ZobristSideToMove;
 
 void zobrist_init(void)
 {
@@ -51,5 +51,5 @@ void zobrist_init(void)
     }
 
     // Initialize the Zobrist key for the side to move.
-    ZobristBlackToMove = qrandom(&seed);
+    ZobristSideToMove = qrandom(&seed);
 }

--- a/src/sources/history.c
+++ b/src/sources/history.c
@@ -35,10 +35,10 @@ void update_quiet_history(const Board *board, int depth, move_t bestmove, const 
     int qcount, Searchstack *ss)
 {
     butterfly_history_t *bfHist = &get_worker(board)->bfHistory;
+    const int bonus = history_bonus(depth);
+    const move_t previousMove = (ss - 1)->currentMove;
     square_t to;
     piece_t piece;
-    int bonus = history_bonus(depth);
-    move_t previousMove = (ss - 1)->currentMove;
 
     piece = piece_on(board, from_sq(bestmove));
     to = to_sq(bestmove);
@@ -75,9 +75,8 @@ void update_quiet_history(const Board *board, int depth, move_t bestmove, const 
 
 void update_single_capture(capture_history_t *capHist, const Board *board, move_t move, int bonus)
 {
-    square_t from = from_sq(move);
-    piece_t movedPiece = piece_on(board, from);
-    square_t to = to_sq(move);
+    const piece_t movedPiece = piece_on(board, from_sq(move));
+    const square_t to = to_sq(move);
     piecetype_t captured = piece_type(piece_on(board, to));
 
     if (move_type(move) == PROMOTION)
@@ -93,7 +92,7 @@ void update_capture_history(const Board *board, int depth, move_t bestmove,
 {
     (void)ss;
     capture_history_t *capHist = &get_worker(board)->capHistory;
-    int bonus = history_bonus(depth);
+    const int bonus = history_bonus(depth);
 
     // Apply history bonuses to the bestmove.
     if (is_capture_or_promotion(board, bestmove))

--- a/src/sources/main.c
+++ b/src/sources/main.c
@@ -74,7 +74,11 @@ int main(int argc, char **argv)
     // commands.
     worker_wait_search_end(wpool_main_worker(&SearchWorkerPool));
     uci_loop(argc, argv);
+
+    // Destroy all allocated memory.
     wpool_init(&SearchWorkerPool, 0);
+    tt_resize(0);
+    free_boardstack(UciBoard.stack);
 
 #endif
 

--- a/src/sources/movelist.c
+++ b/src/sources/movelist.c
@@ -53,8 +53,8 @@ void place_top_move(ExtendedMove *begin, ExtendedMove *end)
     *begin = tmp;
 }
 
-ExtendedMove *generate_piece_moves(
-    ExtendedMove *movelist, const Board *board, color_t us, piecetype_t pt, bitboard_t target)
+ExtendedMove *generate_piece_moves(ExtendedMove *restrict movelist, const Board *restrict board,
+    color_t us, piecetype_t pt, bitboard_t target)
 {
     bitboard_t bb = piece_bb(board, us, pt);
     bitboard_t occupancy = occupancy_bb(board);
@@ -72,8 +72,8 @@ ExtendedMove *generate_piece_moves(
     return movelist;
 }
 
-ExtendedMove *generate_pawn_capture_moves(
-    ExtendedMove *movelist, const Board *board, color_t us, bitboard_t theirPieces, bool inQsearch)
+ExtendedMove *generate_pawn_capture_moves(ExtendedMove *restrict movelist,
+    const Board *restrict board, color_t us, bitboard_t theirPieces, bool inQsearch)
 {
     int pawnPush = pawn_direction(us);
     bitboard_t pawnsOnLastRank = piece_bb(board, us, PAWN) & (us == WHITE ? RANK_7_BB : RANK_2_BB);
@@ -143,7 +143,8 @@ ExtendedMove *generate_pawn_capture_moves(
     return movelist;
 }
 
-ExtendedMove *generate_captures(ExtendedMove *movelist, const Board *board, bool inQsearch)
+ExtendedMove *generate_captures(
+    ExtendedMove *restrict movelist, const Board *restrict board, bool inQsearch)
 {
     color_t us = board->sideToMove;
     bitboard_t target = color_bb(board, not_color(us));
@@ -163,7 +164,8 @@ ExtendedMove *generate_captures(ExtendedMove *movelist, const Board *board, bool
     return movelist;
 }
 
-ExtendedMove *generate_quiet_pawn_moves(ExtendedMove *movelist, const Board *board, color_t us)
+ExtendedMove *generate_quiet_pawn_moves(
+    ExtendedMove *restrict movelist, const Board *restrict board, color_t us)
 {
     int pawnPush = pawn_direction(us);
     bitboard_t pawnsNotOnLastRank =
@@ -189,7 +191,7 @@ ExtendedMove *generate_quiet_pawn_moves(ExtendedMove *movelist, const Board *boa
     return movelist;
 }
 
-ExtendedMove *generate_quiet(ExtendedMove *movelist, const Board *board)
+ExtendedMove *generate_quiet(ExtendedMove *restrict movelist, const Board *restrict board)
 {
     color_t us = board->sideToMove;
     bitboard_t target = ~occupancy_bb(board);
@@ -219,7 +221,8 @@ ExtendedMove *generate_quiet(ExtendedMove *movelist, const Board *board)
     return movelist;
 }
 
-ExtendedMove *generate_classic_pawn_moves(ExtendedMove *movelist, const Board *board, color_t us)
+ExtendedMove *generate_classic_pawn_moves(
+    ExtendedMove *restrict movelist, const Board *restrict board, color_t us)
 {
     int pawnPush = pawn_direction(us);
     bitboard_t pawnsOnLastRank = piece_bb(board, us, PAWN) & (us == WHITE ? RANK_7_BB : RANK_2_BB);
@@ -288,7 +291,7 @@ ExtendedMove *generate_classic_pawn_moves(ExtendedMove *movelist, const Board *b
     return movelist;
 }
 
-ExtendedMove *generate_classic(ExtendedMove *movelist, const Board *board)
+ExtendedMove *generate_classic(ExtendedMove *restrict movelist, const Board *restrict board)
 {
     color_t us = board->sideToMove;
     bitboard_t target = ~color_bb(board, us);
@@ -320,8 +323,8 @@ ExtendedMove *generate_classic(ExtendedMove *movelist, const Board *board)
     return movelist;
 }
 
-ExtendedMove *generate_pawn_evasion_moves(
-    ExtendedMove *movelist, const Board *board, bitboard_t blockSquares, color_t us)
+ExtendedMove *generate_pawn_evasion_moves(ExtendedMove *restrict movelist,
+    const Board *restrict board, bitboard_t blockSquares, color_t us)
 {
     int pawnPush = pawn_direction(us);
     bitboard_t pawnsOnLastRank = piece_bb(board, us, PAWN) & (us == WHITE ? RANK_7_BB : RANK_2_BB);
@@ -397,7 +400,7 @@ ExtendedMove *generate_pawn_evasion_moves(
     return movelist;
 }
 
-ExtendedMove *generate_evasions(ExtendedMove *movelist, const Board *board)
+ExtendedMove *generate_evasions(ExtendedMove *restrict movelist, const Board *restrict board)
 {
     color_t us = board->sideToMove;
     square_t kingSquare = get_king_square(board, us);
@@ -433,7 +436,7 @@ ExtendedMove *generate_evasions(ExtendedMove *movelist, const Board *board)
     return movelist;
 }
 
-ExtendedMove *generate_all(ExtendedMove *movelist, const Board *board)
+ExtendedMove *generate_all(ExtendedMove *restrict movelist, const Board *restrict board)
 {
     color_t us = board->sideToMove;
     bitboard_t pinned = board->stack->kingBlockers[us] & color_bb(board, us);

--- a/src/sources/movepick.c
+++ b/src/sources/movepick.c
@@ -141,7 +141,7 @@ static void score_evasions(Movepicker *mp, ExtendedMove *begin, ExtendedMove *en
 
 move_t movepicker_next_move(Movepicker *mp, bool skipQuiets, int see_threshold)
 {
-__top:
+top:
 
     switch (mp->stage)
     {
@@ -180,7 +180,7 @@ __top:
             {
                 mp->cur = mp->list.moves;
                 mp->stage = PICK_BAD_INSTABLE;
-                goto __top;
+                goto top;
             }
             ++mp->stage;
             // Fallthrough

--- a/src/sources/timeman.c
+++ b/src/sources/timeman.c
@@ -189,16 +189,10 @@ void check_time(void)
 
     // If we are in infinite mode, or the stop has already been set,
     // we can safely return.
-    if (UciSearchParams.infinite || SearchWorkerPool.stop) return;
+    if (UciSearchParams.infinite || wpool_is_stopped(&SearchWorkerPool)) return;
 
-    // Check if we went over the requested node count.
-    if (wpool_get_total_nodes(&SearchWorkerPool) >= UciSearchParams.nodes) goto __set_stop;
-
-    // Check if we went over maximal time usage.
-    if (timeman_must_stop_search(&SearchTimeman, chess_clock())) goto __set_stop;
-
-    return;
-
-__set_stop:
-    SearchWorkerPool.stop = true;
+    // Check if we went over the requested node count or the maximal time usage.
+    if (wpool_get_total_nodes(&SearchWorkerPool) >= UciSearchParams.nodes
+        || timeman_must_stop_search(&SearchTimeman, chess_clock()))
+        wpool_stop(&SearchWorkerPool);
 }

--- a/src/sources/tt.c
+++ b/src/sources/tt.c
@@ -100,6 +100,13 @@ void tt_resize(size_t mbsize)
     // Free the old TT if it exists.
     if (SearchTT.table) free(SearchTT.table);
 
+    if (mbsize == 0)
+    {
+        SearchTT.clusterCount = 0;
+        SearchTT.table = NULL;
+        return;
+    }
+
     SearchTT.clusterCount = mbsize * 1024 * 1024 / sizeof(TT_Cluster);
     SearchTT.table = malloc(SearchTT.clusterCount * sizeof(TT_Cluster));
 

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.4"
+#define UCI_VERSION "v35.5"
 
 // clang-format off
 
@@ -258,11 +258,11 @@ void uci_isready(const char *args __attribute__((unused)))
     fflush(stdout);
 }
 
-void uci_quit(const char *args __attribute__((unused))) { SearchWorkerPool.stop = true; }
+void uci_quit(const char *args __attribute__((unused))) { wpool_stop(&SearchWorkerPool); }
 
-void uci_stop(const char *args __attribute__((unused))) { SearchWorkerPool.stop = true; }
+void uci_stop(const char *args __attribute__((unused))) { wpool_stop(&SearchWorkerPool); }
 
-void uci_ponderhit(const char *args __attribute__((unused))) { SearchWorkerPool.ponder = false; }
+void uci_ponderhit(const char *args __attribute__((unused))) { wpool_ponderhit(&SearchWorkerPool); }
 
 void uci_uci(const char *args __attribute__((unused)))
 {

--- a/src/sources/worker.c
+++ b/src/sources/worker.c
@@ -230,8 +230,8 @@ void wpool_start_search(WorkerPool *wpool, const Board *rootBoard, const SearchP
 
     // Reset the stop flag, and set the ponder flag if indicated by the "go"
     // command.
-    wpool->stop = false;
-    wpool->ponder = searchParams->ponder;
+    atomic_store_explicit(&wpool->stop, false, memory_order_relaxed);
+    atomic_store_explicit(&wpool->ponder, searchParams->ponder, memory_order_relaxed);
 
     for (size_t i = 0; i < wpool->size; ++i)
     {


### PR DESCRIPTION
- Improved loads/stores on atomic booleans to always be explicit
- Simplified bench function
- Fixed the measured time in bench by removing 'ucinewgame' exec time
- Added 'restrict' qualifiers in the move generator
- Replaced all bitboard macros by static constants
- Simplified cyclic tables' initialization
- Slight renames for a few variables/constants

Passed non-regression STC:
```
Elo   | 0.46 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 30210 W: 5791 L: 5751 D: 18668
Penta | [347, 2923, 8520, 2973, 342]
```
http://chess.grantnet.us/test/34674/

Bench: 5,423,868