### PR TITLE
Tune all search constants with SPSA

### DIFF
--- a/src/include/history.h
+++ b/src/include/history.h
@@ -38,7 +38,7 @@ typedef move_t countermove_history_t[PIECE_NB][SQUARE_NB];
 // Returns the history bonus for the given depth.
 INLINED int history_bonus(int depth)
 {
-    return depth <= 11 ? 24 * depth * depth + 1 * depth + 0 : 2563;
+    return depth <= 11 ? 24 * depth * depth + 0 * depth + 1 : 2615;
 }
 
 // Updates the butterfly history table for the given piece and move.

--- a/src/include/history.h
+++ b/src/include/history.h
@@ -38,7 +38,7 @@ typedef move_t countermove_history_t[PIECE_NB][SQUARE_NB];
 // Returns the history bonus for the given depth.
 INLINED int history_bonus(int depth)
 {
-    return depth <= 11 ? 23 * depth * depth + 1 * depth + 2 : 2373;
+    return depth <= 11 ? 24 * depth * depth + 1 * depth + 0 : 2563;
 }
 
 // Updates the butterfly history table for the given piece and move.

--- a/src/include/history.h
+++ b/src/include/history.h
@@ -36,10 +36,7 @@ typedef piece_history_t continuation_history_t[PIECE_NB][SQUARE_NB];
 typedef move_t countermove_history_t[PIECE_NB][SQUARE_NB];
 
 // Returns the history bonus for the given depth.
-INLINED int history_bonus(int depth)
-{
-    return depth <= 11 ? 24 * depth * depth + 0 * depth + 1 : 2615;
-}
+INLINED int history_bonus(int depth) { return depth <= 11 ? 24 * depth * depth + depth : 2563; }
 
 // Updates the butterfly history table for the given piece and move.
 INLINED void add_bf_history(butterfly_history_t hist, piece_t piece, move_t move, int32_t bonus)

--- a/src/include/history.h
+++ b/src/include/history.h
@@ -38,7 +38,7 @@ typedef move_t countermove_history_t[PIECE_NB][SQUARE_NB];
 // Returns the history bonus for the given depth.
 INLINED int history_bonus(int depth)
 {
-    return depth <= 11 ? 20 * depth * depth + 4 * depth + 2 : 2303;
+    return depth <= 11 ? 23 * depth * depth + 1 * depth + 2 : 2373;
 }
 
 // Updates the butterfly history table for the given piece and move.

--- a/src/include/history.h
+++ b/src/include/history.h
@@ -38,7 +38,7 @@ typedef move_t countermove_history_t[PIECE_NB][SQUARE_NB];
 // Returns the history bonus for the given depth.
 INLINED int history_bonus(int depth)
 {
-    return depth <= 11 ? 19 * depth * depth + 1 * depth + 1 : 2068;
+    return depth <= 11 ? 20 * depth * depth + 4 * depth + 2 : 2303;
 }
 
 // Updates the butterfly history table for the given piece and move.

--- a/src/include/history.h
+++ b/src/include/history.h
@@ -38,7 +38,7 @@ typedef move_t countermove_history_t[PIECE_NB][SQUARE_NB];
 // Returns the history bonus for the given depth.
 INLINED int history_bonus(int depth)
 {
-    return depth <= 11 ? 17 * depth * depth + 3 * depth + 1 : 2116;
+    return depth <= 11 ? 19 * depth * depth + 1 * depth + 1 : 2068;
 }
 
 // Updates the butterfly history table for the given piece and move.

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -36,21 +36,21 @@ void init_search_tables(void)
     // Compute the LMR base values.
     for (int i = 1; i < 256; ++i)
     {
-        Reductions[0][i] = (int)(log(i) * 10.43 + 4.31); // Noisy LMR formula
-        Reductions[1][i] = (int)(log(i) * 21.19 + 10.88); // Quiet LMR formula
+        Reductions[0][i] = (int)(log(i) * 10.81 + 4.15);  // Noisy LMR formula
+        Reductions[1][i] = (int)(log(i) * 20.76 + 10.69); // Quiet LMR formula
     }
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 16; ++d)
     {
-        Pruning[1][d] = +2.64 + 3.06 * pow(d, 0.75);
-        Pruning[0][d] = -1.14 + 2.38 * pow(d, 0.63);
+        Pruning[1][d] = +2.57 + 2.97 * pow(d, 0.79);
+        Pruning[0][d] = -1.27 + 2.49 * pow(d, 0.60);
     }
 }
 
 int lmr_base_value(int depth, int movecount, bool improving, bool isQuiet)
 {
-    return (-347 + Reductions[isQuiet][depth] * Reductions[isQuiet][movecount] + !improving * 541)
+    return (-415 + Reductions[isQuiet][depth] * Reductions[isQuiet][movecount] + !improving * 538)
            / 1024;
 }
 
@@ -257,7 +257,7 @@ void worker_search(Worker *worker)
             }
             else
             {
-                delta = 7 + abs(pvScore) / 74;
+                delta = 8 + abs(pvScore) / 82;
                 alpha = imax(-INF_SCORE, pvScore - delta);
                 beta = imin(INF_SCORE, pvScore + delta);
             }
@@ -311,14 +311,14 @@ retry_search:
                 depth = iterDepth;
                 beta = (alpha + beta) / 2;
                 alpha = imax(-INF_SCORE, (int)pvScore - delta);
-                delta += delta * 82 / 256;
+                delta += delta * 79 / 256;
                 goto retry_search;
             }
             else if (bound == LOWER_BOUND)
             {
                 depth -= (depth > iterDepth / 2);
                 beta = imin(INF_SCORE, (int)pvScore + delta);
-                delta += delta * 82 / 256;
+                delta += delta * 79 / 256;
                 goto retry_search;
             }
         }
@@ -465,7 +465,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
 
     // Razoring. If our static eval isn't good, and depth is low, it is likely
     // that only a capture will save us at this stage. Drop into qsearch.
-    if (!pvNode && depth == 1 && ss->staticEval + 133 <= alpha)
+    if (!pvNode && depth == 1 && ss->staticEval + 135 <= alpha)
         return qsearch(false, board, alpha, beta, ss);
 
     improving = ss->plies >= 2 && ss->staticEval > (ss - 2)->staticEval;
@@ -473,7 +473,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     // Futility Pruning. If our eval is quite good and depth is low, we just
     // assume that we won't fall far behind in the next plies, and we return the
     // eval.
-    if (!pvNode && depth <= 7 && eval - 88 * depth + 74 * improving >= beta && eval < VICTORY)
+    if (!pvNode && depth <= 8 && eval - 85 * depth + 73 * improving >= beta && eval < VICTORY)
         return eval;
 
     // Null Move Pruning. If our eval currently beats beta, and we still have
@@ -486,7 +486,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
         Boardstack stack;
 
         // Compute the depth reduction based on depth and eval difference with beta.
-        int R = (828 + 65 * depth) / 256 + imin((eval - beta) / 106, 5);
+        int R = (792 + 67 * depth) / 256 + imin((eval - beta) / 109, 5);
 
         ss->currentMove = NULL_MOVE;
         ss->pieceHistory = NULL;
@@ -524,10 +524,10 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     // Probcut. If we have a good enough capture (or promotion) and a reduced
     // search returns a value much above beta, we can (almost) safely prune the
     // previous move.
-    const score_t probCutBeta = beta + 138;
+    const score_t probCutBeta = beta + 140;
 
-    if (!rootNode && depth >= 5 && abs(beta) < VICTORY
-        && !(found && ttDepth >= depth - 5 && ttScore < probCutBeta))
+    if (!rootNode && depth >= 6 && abs(beta) < VICTORY
+        && !(found && ttDepth >= depth - 4 && ttScore < probCutBeta))
     {
         const score_t probCutSEE = probCutBeta - ss->staticEval;
         move_t currmove;
@@ -609,19 +609,19 @@ main_loop:
 
             // Futility Pruning. For low-depth nodes, stop searching quiets if
             // the eval suggests that only captures will save the day.
-            if (depth <= 7 && !inCheck && isQuiet && eval + 186 + 66 * depth <= alpha)
+            if (depth <= 7 && !inCheck && isQuiet && eval + 186 + 67 * depth <= alpha)
                 skipQuiets = true;
 
             // Continuation History Pruning. For low-depth nodes, prune quiet moves if
             // they seem to be bad continuations to the previous moves.
-            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 563 - 2844 * (depth - 1))
+            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 421 - 2839 * (depth - 1))
                 continue;
 
             // SEE Pruning. For low-depth nodes, don't search moves which seem
             // to lose too much material to be interesting.
             if (depth <= 12
                 && !see_greater_than(
-                    board, currmove, (isQuiet ? -46 * depth : -23 * depth * depth)))
+                    board, currmove, (isQuiet ? -49 * depth : -22 * depth * depth)))
                 continue;
         }
 
@@ -654,7 +654,7 @@ main_loop:
                 && abs(ttScore) < VICTORY && ttDepth >= depth - 3)
             {
                 score_t singularBeta = ttScore - 11 * depth / 16;
-                int singularDepth = (depth + 2) / 2;
+                int singularDepth = depth / 2 + 1;
 
                 // Exclude the TT move from the singular search.
                 ss->excludedMove = ttMove;
@@ -666,7 +666,7 @@ main_loop:
                 // move.
                 if (singularScore < singularBeta)
                 {
-                    if (!pvNode && singularBeta - singularScore > 15 && ss->doubleExtensions <= 9)
+                    if (!pvNode && singularBeta - singularScore > 17 && ss->doubleExtensions <= 9)
                     {
                         extension = 2;
                         ss->doubleExtensions++;
@@ -723,7 +723,7 @@ main_loop:
             R -= isQuiet && !see_greater_than(board, reverse_move(currmove), 0);
 
             // Increase/decrease the reduction based on the move's history.
-            R -= iclamp(histScore / 6413, -4, 4);
+            R -= iclamp(histScore / 6307, -3, 3);
 
             // Clamp the reduction so that we don't extend the move or drop
             // immediately into qsearch.
@@ -926,7 +926,7 @@ score_t qsearch(bool pvNode, Board *board, score_t alpha, score_t beta, Searchst
 
     // Check if Futility Pruning is possible in the moves loop.
     const bool canFutilityPrune = (!inCheck && popcount(occupancy_bb(board)) >= 5);
-    const score_t futilityBase = bestScore + 108;
+    const score_t futilityBase = bestScore + 110;
 
     while ((currmove = movepicker_next_move(&mp, false, 0)) != NO_MOVE)
     {

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -36,21 +36,21 @@ void init_search_tables(void)
     // Compute the LMR base values.
     for (int i = 1; i < 256; ++i)
     {
-        Reductions[0][i] = (int)(log(i) * 11.99 + 4.73); // Noisy LMR formula
-        Reductions[1][i] = (int)(log(i) * 22.97 + 9.33); // Quiet LMR formula
+        Reductions[0][i] = (int)(log(i) * 11.33 + 4.40); // Noisy LMR formula
+        Reductions[1][i] = (int)(log(i) * 22.38 + 9.92); // Quiet LMR formula
     }
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 16; ++d)
     {
-        Pruning[1][d] = +2.78 + 3.48 * pow(d, 0.80);
-        Pruning[0][d] = -1.54 + 2.89 * pow(d, 0.56);
+        Pruning[1][d] = +2.68 + 3.35 * pow(d, 0.82);
+        Pruning[0][d] = -1.46 + 2.67 * pow(d, 0.59);
     }
 }
 
 int lmr_base_value(int depth, int movecount, bool improving, bool isQuiet)
 {
-    return (-676 + Reductions[isQuiet][depth] * Reductions[isQuiet][movecount] + !improving * 407)
+    return (-696 + Reductions[isQuiet][depth] * Reductions[isQuiet][movecount] + !improving * 442)
            / 1024;
 }
 
@@ -257,7 +257,7 @@ void worker_search(Worker *worker)
             }
             else
             {
-                delta = 10 + abs(pvScore) / 80;
+                delta = 10 + abs(pvScore) / 72;
                 alpha = imax(-INF_SCORE, pvScore - delta);
                 beta = imin(INF_SCORE, pvScore + delta);
             }
@@ -311,14 +311,14 @@ retry_search:
                 depth = iterDepth;
                 beta = (alpha + beta) / 2;
                 alpha = imax(-INF_SCORE, (int)pvScore - delta);
-                delta += delta * 69 / 256;
+                delta += delta * 77 / 256;
                 goto retry_search;
             }
             else if (bound == LOWER_BOUND)
             {
                 depth -= (depth > iterDepth / 2);
                 beta = imin(INF_SCORE, (int)pvScore + delta);
-                delta += delta * 69 / 256;
+                delta += delta * 77 / 256;
                 goto retry_search;
             }
         }
@@ -465,7 +465,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
 
     // Razoring. If our static eval isn't good, and depth is low, it is likely
     // that only a capture will save us at this stage. Drop into qsearch.
-    if (!pvNode && depth == 1 && ss->staticEval + 147 <= alpha)
+    if (!pvNode && depth == 1 && ss->staticEval + 149 <= alpha)
         return qsearch(false, board, alpha, beta, ss);
 
     improving = ss->plies >= 2 && ss->staticEval > (ss - 2)->staticEval;
@@ -473,7 +473,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     // Futility Pruning. If our eval is quite good and depth is low, we just
     // assume that we won't fall far behind in the next plies, and we return the
     // eval.
-    if (!pvNode && depth <= 7 && eval - 86 * depth + 70 * improving >= beta && eval < VICTORY)
+    if (!pvNode && depth <= 7 && eval - 85 * depth + 69 * improving >= beta && eval < VICTORY)
         return eval;
 
     // Null Move Pruning. If our eval currently beats beta, and we still have
@@ -486,7 +486,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
         Boardstack stack;
 
         // Compute the depth reduction based on depth and eval difference with beta.
-        int R = (801 + 67 * depth) / 256 + imin((eval - beta) / 126, 2);
+        int R = (799 + 66 * depth) / 256 + imin((eval - beta) / 118, 3);
 
         ss->currentMove = NULL_MOVE;
         ss->pieceHistory = NULL;
@@ -506,7 +506,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
 
             // Do not trust win claims for the same reason as above, and do not
             // return early for high-depth searches.
-            if (worker->verifPlies || (depth <= 10 && abs(beta) < VICTORY)) return score;
+            if (worker->verifPlies || (depth <= 11 && abs(beta) < VICTORY)) return score;
 
             // Zugzwang checking. For high depth nodes, we perform a second
             // reduced search at the same depth, but this time with NMP disabled
@@ -524,9 +524,9 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     // Probcut. If we have a good enough capture (or promotion) and a reduced
     // search returns a value much above beta, we can (almost) safely prune the
     // previous move.
-    const score_t probCutBeta = beta + 136;
+    const score_t probCutBeta = beta + 133;
 
-    if (!rootNode && depth >= 5 && abs(beta) < VICTORY
+    if (!rootNode && depth >= 6 && abs(beta) < VICTORY
         && !(found && ttDepth >= depth - 5 && ttScore < probCutBeta))
     {
         const score_t probCutSEE = probCutBeta - ss->staticEval;
@@ -609,19 +609,19 @@ main_loop:
 
             // Futility Pruning. For low-depth nodes, stop searching quiets if
             // the eval suggests that only captures will save the day.
-            if (depth <= 5 && !inCheck && isQuiet && eval + 207 + 70 * depth <= alpha)
+            if (depth <= 6 && !inCheck && isQuiet && eval + 199 + 74 * depth <= alpha)
                 skipQuiets = true;
 
             // Continuation History Pruning. For low-depth nodes, prune quiet moves if
             // they seem to be bad continuations to the previous moves.
-            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 188 - 3735 * (depth - 1))
+            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 258 - 3428 * (depth - 1))
                 continue;
 
             // SEE Pruning. For low-depth nodes, don't search moves which seem
             // to lose too much material to be interesting.
             if (depth <= 9
                 && !see_greater_than(
-                    board, currmove, (isQuiet ? -65 * depth : -22 * depth * depth)))
+                    board, currmove, (isQuiet ? -60 * depth : -22 * depth * depth)))
                 continue;
         }
 
@@ -650,11 +650,11 @@ main_loop:
             // that's not the case, we consider the TT move to be singular, and
             // we extend non-LMR searches by one or two lies, depending on the
             // margin that the singular search failed low.
-            if (depth >= 7 && currmove == ttMove && !ss->excludedMove && (ttBound & LOWER_BOUND)
+            if (depth >= 8 && currmove == ttMove && !ss->excludedMove && (ttBound & LOWER_BOUND)
                 && abs(ttScore) < VICTORY && ttDepth >= depth - 3)
             {
-                score_t singularBeta = ttScore - 12 * depth / 16;
-                int singularDepth = (depth + 0) / 2;
+                score_t singularBeta = ttScore - 13 * depth / 16;
+                int singularDepth = (depth + 1) / 2;
 
                 // Exclude the TT move from the singular search.
                 ss->excludedMove = ttMove;
@@ -666,7 +666,7 @@ main_loop:
                 // move.
                 if (singularScore < singularBeta)
                 {
-                    if (!pvNode && singularBeta - singularScore > 18 && ss->doubleExtensions <= 7)
+                    if (!pvNode && singularBeta - singularScore > 17 && ss->doubleExtensions <= 8)
                     {
                         extension = 2;
                         ss->doubleExtensions++;
@@ -723,7 +723,7 @@ main_loop:
             R -= isQuiet && !see_greater_than(board, reverse_move(currmove), 0);
 
             // Increase/decrease the reduction based on the move's history.
-            R -= iclamp(histScore / 6136, -4, 4);
+            R -= iclamp(histScore / 6345, -3, 3);
 
             // Clamp the reduction so that we don't extend the move or drop
             // immediately into qsearch.
@@ -926,7 +926,7 @@ score_t qsearch(bool pvNode, Board *board, score_t alpha, score_t beta, Searchst
 
     // Check if Futility Pruning is possible in the moves loop.
     const bool canFutilityPrune = (!inCheck && popcount(occupancy_bb(board)) >= 5);
-    const score_t futilityBase = bestScore + 121;
+    const score_t futilityBase = bestScore + 115;
 
     while ((currmove = movepicker_next_move(&mp, false, 0)) != NO_MOVE)
     {

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -36,21 +36,21 @@ void init_search_tables(void)
     // Compute the LMR base values.
     for (int i = 1; i < 256; ++i)
     {
-        Reductions[0][i] = (int)(log(i) * 10.81 + 4.15); // Noisy LMR formula
-        Reductions[1][i] = (int)(log(i) * 20.76 + 10.69); // Quiet LMR formula
+        Reductions[0][i] = (int)(log(i) * 10.43 + 4.31); // Noisy LMR formula
+        Reductions[1][i] = (int)(log(i) * 21.19 + 10.88); // Quiet LMR formula
     }
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 16; ++d)
     {
-        Pruning[1][d] = +2.57 + 2.97 * pow(d, 0.79);
-        Pruning[0][d] = -1.27 + 2.49 * pow(d, 0.60);
+        Pruning[1][d] = +2.64 + 3.06 * pow(d, 0.75);
+        Pruning[0][d] = -1.14 + 2.38 * pow(d, 0.63);
     }
 }
 
 int lmr_base_value(int depth, int movecount, bool improving, bool isQuiet)
 {
-    return (-415 + Reductions[isQuiet][depth] * Reductions[isQuiet][movecount] + !improving * 538)
+    return (-347 + Reductions[isQuiet][depth] * Reductions[isQuiet][movecount] + !improving * 541)
            / 1024;
 }
 
@@ -257,7 +257,7 @@ void worker_search(Worker *worker)
             }
             else
             {
-                delta = 8 + abs(pvScore) / 82;
+                delta = 7 + abs(pvScore) / 74;
                 alpha = imax(-INF_SCORE, pvScore - delta);
                 beta = imin(INF_SCORE, pvScore + delta);
             }
@@ -311,14 +311,14 @@ retry_search:
                 depth = iterDepth;
                 beta = (alpha + beta) / 2;
                 alpha = imax(-INF_SCORE, (int)pvScore - delta);
-                delta += delta * 79 / 256;
+                delta += delta * 82 / 256;
                 goto retry_search;
             }
             else if (bound == LOWER_BOUND)
             {
                 depth -= (depth > iterDepth / 2);
                 beta = imin(INF_SCORE, (int)pvScore + delta);
-                delta += delta * 79 / 256;
+                delta += delta * 82 / 256;
                 goto retry_search;
             }
         }
@@ -465,7 +465,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
 
     // Razoring. If our static eval isn't good, and depth is low, it is likely
     // that only a capture will save us at this stage. Drop into qsearch.
-    if (!pvNode && depth == 1 && ss->staticEval + 135 <= alpha)
+    if (!pvNode && depth == 1 && ss->staticEval + 133 <= alpha)
         return qsearch(false, board, alpha, beta, ss);
 
     improving = ss->plies >= 2 && ss->staticEval > (ss - 2)->staticEval;
@@ -473,7 +473,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     // Futility Pruning. If our eval is quite good and depth is low, we just
     // assume that we won't fall far behind in the next plies, and we return the
     // eval.
-    if (!pvNode && depth <= 8 && eval - 85 * depth + 73 * improving >= beta && eval < VICTORY)
+    if (!pvNode && depth <= 7 && eval - 88 * depth + 74 * improving >= beta && eval < VICTORY)
         return eval;
 
     // Null Move Pruning. If our eval currently beats beta, and we still have
@@ -486,7 +486,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
         Boardstack stack;
 
         // Compute the depth reduction based on depth and eval difference with beta.
-        int R = (792 + 67 * depth) / 256 + imin((eval - beta) / 109, 5);
+        int R = (828 + 65 * depth) / 256 + imin((eval - beta) / 106, 5);
 
         ss->currentMove = NULL_MOVE;
         ss->pieceHistory = NULL;
@@ -524,10 +524,10 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     // Probcut. If we have a good enough capture (or promotion) and a reduced
     // search returns a value much above beta, we can (almost) safely prune the
     // previous move.
-    const score_t probCutBeta = beta + 140;
+    const score_t probCutBeta = beta + 138;
 
-    if (!rootNode && depth >= 6 && abs(beta) < VICTORY
-        && !(found && ttDepth >= depth - 4 && ttScore < probCutBeta))
+    if (!rootNode && depth >= 5 && abs(beta) < VICTORY
+        && !(found && ttDepth >= depth - 5 && ttScore < probCutBeta))
     {
         const score_t probCutSEE = probCutBeta - ss->staticEval;
         move_t currmove;
@@ -609,19 +609,19 @@ main_loop:
 
             // Futility Pruning. For low-depth nodes, stop searching quiets if
             // the eval suggests that only captures will save the day.
-            if (depth <= 7 && !inCheck && isQuiet && eval + 186 + 67 * depth <= alpha)
+            if (depth <= 7 && !inCheck && isQuiet && eval + 186 + 66 * depth <= alpha)
                 skipQuiets = true;
 
             // Continuation History Pruning. For low-depth nodes, prune quiet moves if
             // they seem to be bad continuations to the previous moves.
-            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 421 - 2839 * (depth - 1))
+            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 563 - 2844 * (depth - 1))
                 continue;
 
             // SEE Pruning. For low-depth nodes, don't search moves which seem
             // to lose too much material to be interesting.
             if (depth <= 12
                 && !see_greater_than(
-                    board, currmove, (isQuiet ? -49 * depth : -22 * depth * depth)))
+                    board, currmove, (isQuiet ? -46 * depth : -23 * depth * depth)))
                 continue;
         }
 
@@ -666,7 +666,7 @@ main_loop:
                 // move.
                 if (singularScore < singularBeta)
                 {
-                    if (!pvNode && singularBeta - singularScore > 17 && ss->doubleExtensions <= 9)
+                    if (!pvNode && singularBeta - singularScore > 15 && ss->doubleExtensions <= 9)
                     {
                         extension = 2;
                         ss->doubleExtensions++;
@@ -723,7 +723,7 @@ main_loop:
             R -= isQuiet && !see_greater_than(board, reverse_move(currmove), 0);
 
             // Increase/decrease the reduction based on the move's history.
-            R -= iclamp(histScore / 6307, -3, 3);
+            R -= iclamp(histScore / 6413, -4, 4);
 
             // Clamp the reduction so that we don't extend the move or drop
             // immediately into qsearch.
@@ -926,7 +926,7 @@ score_t qsearch(bool pvNode, Board *board, score_t alpha, score_t beta, Searchst
 
     // Check if Futility Pruning is possible in the moves loop.
     const bool canFutilityPrune = (!inCheck && popcount(occupancy_bb(board)) >= 5);
-    const score_t futilityBase = bestScore + 110;
+    const score_t futilityBase = bestScore + 108;
 
     while ((currmove = movepicker_next_move(&mp, false, 0)) != NO_MOVE)
     {

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -36,21 +36,21 @@ void init_search_tables(void)
     // Compute the LMR base values.
     for (int i = 1; i < 256; ++i)
     {
-        Reductions[0][i] = (int)(log(i) * 11.33 + 4.40); // Noisy LMR formula
-        Reductions[1][i] = (int)(log(i) * 22.38 + 9.92); // Quiet LMR formula
+        Reductions[0][i] = (int)(log(i) * 10.58 + 4.42); // Noisy LMR formula
+        Reductions[1][i] = (int)(log(i) * 22.70 + 10.33); // Quiet LMR formula
     }
 
     // Compute the LMP movecount values based on depth.
     for (int d = 1; d < 16; ++d)
     {
-        Pruning[1][d] = +2.68 + 3.35 * pow(d, 0.82);
-        Pruning[0][d] = -1.46 + 2.67 * pow(d, 0.59);
+        Pruning[1][d] = +2.61 + 3.21 * pow(d, 0.80);
+        Pruning[0][d] = -1.33 + 2.56 * pow(d, 0.59);
     }
 }
 
 int lmr_base_value(int depth, int movecount, bool improving, bool isQuiet)
 {
-    return (-696 + Reductions[isQuiet][depth] * Reductions[isQuiet][movecount] + !improving * 442)
+    return (-637 + Reductions[isQuiet][depth] * Reductions[isQuiet][movecount] + !improving * 521)
            / 1024;
 }
 
@@ -257,7 +257,7 @@ void worker_search(Worker *worker)
             }
             else
             {
-                delta = 10 + abs(pvScore) / 72;
+                delta = 8 + abs(pvScore) / 83;
                 alpha = imax(-INF_SCORE, pvScore - delta);
                 beta = imin(INF_SCORE, pvScore + delta);
             }
@@ -311,14 +311,14 @@ retry_search:
                 depth = iterDepth;
                 beta = (alpha + beta) / 2;
                 alpha = imax(-INF_SCORE, (int)pvScore - delta);
-                delta += delta * 77 / 256;
+                delta += delta * 79 / 256;
                 goto retry_search;
             }
             else if (bound == LOWER_BOUND)
             {
                 depth -= (depth > iterDepth / 2);
                 beta = imin(INF_SCORE, (int)pvScore + delta);
-                delta += delta * 77 / 256;
+                delta += delta * 79 / 256;
                 goto retry_search;
             }
         }
@@ -465,7 +465,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
 
     // Razoring. If our static eval isn't good, and depth is low, it is likely
     // that only a capture will save us at this stage. Drop into qsearch.
-    if (!pvNode && depth == 1 && ss->staticEval + 149 <= alpha)
+    if (!pvNode && depth == 1 && ss->staticEval + 137 <= alpha)
         return qsearch(false, board, alpha, beta, ss);
 
     improving = ss->plies >= 2 && ss->staticEval > (ss - 2)->staticEval;
@@ -473,7 +473,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     // Futility Pruning. If our eval is quite good and depth is low, we just
     // assume that we won't fall far behind in the next plies, and we return the
     // eval.
-    if (!pvNode && depth <= 7 && eval - 85 * depth + 69 * improving >= beta && eval < VICTORY)
+    if (!pvNode && depth <= 8 && eval - 86 * depth + 73 * improving >= beta && eval < VICTORY)
         return eval;
 
     // Null Move Pruning. If our eval currently beats beta, and we still have
@@ -486,7 +486,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
         Boardstack stack;
 
         // Compute the depth reduction based on depth and eval difference with beta.
-        int R = (799 + 66 * depth) / 256 + imin((eval - beta) / 118, 3);
+        int R = (809 + 67 * depth) / 256 + imin((eval - beta) / 116, 4);
 
         ss->currentMove = NULL_MOVE;
         ss->pieceHistory = NULL;
@@ -524,10 +524,10 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     // Probcut. If we have a good enough capture (or promotion) and a reduced
     // search returns a value much above beta, we can (almost) safely prune the
     // previous move.
-    const score_t probCutBeta = beta + 133;
+    const score_t probCutBeta = beta + 135;
 
     if (!rootNode && depth >= 6 && abs(beta) < VICTORY
-        && !(found && ttDepth >= depth - 5 && ttScore < probCutBeta))
+        && !(found && ttDepth >= depth - 4 && ttScore < probCutBeta))
     {
         const score_t probCutSEE = probCutBeta - ss->staticEval;
         move_t currmove;
@@ -609,19 +609,19 @@ main_loop:
 
             // Futility Pruning. For low-depth nodes, stop searching quiets if
             // the eval suggests that only captures will save the day.
-            if (depth <= 6 && !inCheck && isQuiet && eval + 199 + 74 * depth <= alpha)
+            if (depth <= 7 && !inCheck && isQuiet && eval + 185 + 70 * depth <= alpha)
                 skipQuiets = true;
 
             // Continuation History Pruning. For low-depth nodes, prune quiet moves if
             // they seem to be bad continuations to the previous moves.
-            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 258 - 3428 * (depth - 1))
+            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 497 - 3151 * (depth - 1))
                 continue;
 
             // SEE Pruning. For low-depth nodes, don't search moves which seem
             // to lose too much material to be interesting.
-            if (depth <= 9
+            if (depth <= 12
                 && !see_greater_than(
-                    board, currmove, (isQuiet ? -60 * depth : -22 * depth * depth)))
+                    board, currmove, (isQuiet ? -55 * depth : -23 * depth * depth)))
                 continue;
         }
 
@@ -653,7 +653,7 @@ main_loop:
             if (depth >= 8 && currmove == ttMove && !ss->excludedMove && (ttBound & LOWER_BOUND)
                 && abs(ttScore) < VICTORY && ttDepth >= depth - 3)
             {
-                score_t singularBeta = ttScore - 13 * depth / 16;
+                score_t singularBeta = ttScore - 11 * depth / 16;
                 int singularDepth = (depth + 1) / 2;
 
                 // Exclude the TT move from the singular search.
@@ -723,7 +723,7 @@ main_loop:
             R -= isQuiet && !see_greater_than(board, reverse_move(currmove), 0);
 
             // Increase/decrease the reduction based on the move's history.
-            R -= iclamp(histScore / 6345, -3, 3);
+            R -= iclamp(histScore / 6585, -3, 3);
 
             // Clamp the reduction so that we don't extend the move or drop
             // immediately into qsearch.
@@ -926,7 +926,7 @@ score_t qsearch(bool pvNode, Board *board, score_t alpha, score_t beta, Searchst
 
     // Check if Futility Pruning is possible in the moves loop.
     const bool canFutilityPrune = (!inCheck && popcount(occupancy_bb(board)) >= 5);
-    const score_t futilityBase = bestScore + 115;
+    const score_t futilityBase = bestScore + 116;
 
     while ((currmove = movepicker_next_move(&mp, false, 0)) != NO_MOVE)
     {

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.5"
+#define UCI_VERSION "v35.6"
 
 // clang-format off
 


### PR DESCRIPTION
Tuned at 40+0.4, 25k iterations, 400k games
http://chess.grantnet.us/tune/34733/

Using the values after 18k iterations due to unconclusive results from the final values.

Fixed games LTC:
```
Elo   | 25.87 +- 3.33 (95%)
Conf  | 40.0+0.40s Threads=1 Hash=64MB
Games | N: 11854 W: 2141 L: 1260 D: 8453
Penta | [54, 894, 3262, 1551, 166]
```
http://chess.grantnet.us/test/34808/

Bench: 4,401,851