### PR TITLE
Send an info string if we get a fail-low on search abortion

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -274,10 +274,10 @@ retry_search:
 
             // Note: we set the bound to be EXACT_BOUND when the search aborts, even if the last
             // search finished on a fail low/high.
-            int bound = (abs(pvScore) == INF_SCORE) ? EXACT_BOUND
-                        : (pvScore >= beta)         ? LOWER_BOUND
-                        : (pvScore <= alpha)        ? UPPER_BOUND
-                                                    : EXACT_BOUND;
+            int bound = hasSearchAborted     ? EXACT_BOUND
+                        : (pvScore >= beta)  ? LOWER_BOUND
+                        : (pvScore <= alpha) ? UPPER_BOUND
+                                             : EXACT_BOUND;
 
             if (bound == EXACT_BOUND)
                 sort_root_moves(worker->rootMoves, worker->rootMoves + multiPv);

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.8"
+#define UCI_VERSION "v35.9"
 
 // clang-format off
 


### PR DESCRIPTION
Passed non-regression STC:

```
Elo   | -0.45 +- 1.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.10 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 105774 W: 20621 L: 20757 D: 64396
Penta | [1414, 11260, 27588, 11298, 1327]
```
http://chess.grantnet.us/test/35524/

Bench: 4,319,185