### PR TITLE
Make promotions follow standard SEE rules

### DIFF
--- a/src/sources/board.c
+++ b/src/sources/board.c
@@ -1238,8 +1238,9 @@ bool see_greater_than(const Board *board, move_t m, score_t threshold)
     };
 
     // "Non-standard" moves are tricky to evaluate, so perform a generic check
-    // here.
-    if (move_type(m) != NORMAL_MOVE) return threshold <= 0;
+    // here. Note that for now we don't count promotions as having a higher SEE
+    // from the "material gain" of replacing the pawn with a stronger piece.
+    if (move_type(m) != NORMAL_MOVE && move_type(m) != PROMOTION) return threshold <= 0;
 
     const square_t from = from_sq(m), to = to_sq(m);
     score_t nextScore = SeeScores[piece_type(piece_on(board, to))] - threshold;

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.14"
+#define UCI_VERSION "v35.15"
 
 // clang-format off
 


### PR DESCRIPTION
Passed STC:

```
Elo   | 4.22 +- 3.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16472 W: 3331 L: 3131 D: 10010
Penta | [237, 1960, 3693, 2058, 288]
```
http://chess.grantnet.us/test/35828/

Passed LTC:

```
Elo   | 1.86 +- 1.42 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 62712 W: 8741 L: 8405 D: 45566
Penta | [515, 5965, 18082, 6257, 537]
```
http://chess.grantnet.us/test/35830/

Bench: 3,858,596