### PR TITLE
Simplify history downscaling entirely

### DIFF
--- a/src/include/history.h
+++ b/src/include/history.h
@@ -24,9 +24,7 @@
 
 enum
 {
-    HistoryMaxScore = 8192,
-    HistoryScale = 2,
-    HistoryResolution = HistoryMaxScore * HistoryScale
+    HistoryResolution = 16384
 };
 
 typedef int16_t butterfly_history_t[COLOR_NB][SQUARE_NB * SQUARE_NB];
@@ -49,7 +47,7 @@ INLINED void add_bf_history(butterfly_history_t hist, piece_t piece, move_t move
 // Gets the butterfly history bonus for the given piece and move.
 INLINED score_t get_bf_history_score(const butterfly_history_t hist, piece_t piece, move_t move)
 {
-    return hist[piece_color(piece)][square_mask(move)] / HistoryScale;
+    return hist[piece_color(piece)][square_mask(move)];
 }
 
 // Updates the piece history table for the given piece and destination square.
@@ -63,7 +61,7 @@ INLINED void add_pc_history(piece_history_t hist, piece_t pc, square_t to, int32
 // Gets the piece history bonus for the given piece and destination square.
 INLINED score_t get_pc_history_score(const piece_history_t hist, piece_t pc, square_t to)
 {
-    return hist[pc][to] / HistoryScale;
+    return hist[pc][to];
 }
 
 // Updates the capture history table for the given piece, destination square and captured piece.
@@ -79,7 +77,7 @@ INLINED void add_cap_history(
 INLINED score_t get_cap_history_score(
     const capture_history_t hist, piece_t pc, square_t to, piece_t captured)
 {
-    return hist[pc][to][piece_type(captured)] / HistoryScale;
+    return hist[pc][to][piece_type(captured)];
 }
 
 #endif // HISTORY_H

--- a/src/include/movelist.h
+++ b/src/include/movelist.h
@@ -27,7 +27,7 @@
 typedef struct _ExtendedMove
 {
     move_t move;
-    score_t score;
+    int32_t score;
 } ExtendedMove;
 
 // Structure for holding a list of moves

--- a/src/sources/movepick.c
+++ b/src/sources/movepick.c
@@ -54,7 +54,7 @@ void movepicker_init(Movepicker *mp, bool inQsearch, const Board *board, const W
 
 static void score_captures(Movepicker *mp, ExtendedMove *begin, ExtendedMove *end)
 {
-    static const score_t MVV_LVA[PIECETYPE_NB] = {0, 0, 640, 640, 1280, 2560, 0, 0};
+    static const score_t MVV_LVA[PIECETYPE_NB] = {0, 0, 1280, 1280, 2560, 5120, 0, 0};
 
     while (begin < end)
     {
@@ -118,7 +118,7 @@ static void score_evasions(Movepicker *mp, ExtendedMove *begin, ExtendedMove *en
 
             // Place captures of the checking piece at the top of the list using
             // MVV/LVA ordering.
-            begin->score = 28672 + captured * 8 - moved;
+            begin->score = 65536 + captured * 8 - moved;
         }
         else
         {

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -611,7 +611,7 @@ main_loop:
 
             // Continuation History Pruning. For low-depth nodes, prune quiet moves if
             // they seem to be bad continuations to the previous moves.
-            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 421 - 2839 * (depth - 1))
+            if (depth <= 4 && get_conthist_score(board, ss, currmove) < 842 - 5678 * (depth - 1))
                 continue;
 
             // SEE Pruning. For low-depth nodes, don't search moves which seem
@@ -720,7 +720,7 @@ main_loop:
             R -= isQuiet && !see_greater_than(board, reverse_move(currmove), 0);
 
             // Increase/decrease the reduction based on the move's history.
-            R -= iclamp(histScore / 6307, -3, 3);
+            R -= iclamp(histScore / 12614, -3, 3);
 
             // Clamp the reduction so that we don't extend the move or drop
             // immediately into qsearch.


### PR DESCRIPTION
Passed non-regression STC:

```
Elo   | 2.54 +- 3.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 12730 W: 2522 L: 2429 D: 7779
Penta | [207, 1518, 2864, 1527, 249]
```
http://chess.grantnet.us/test/35877/

Passed non-regression LTC:

```
Elo   | 1.36 +- 2.70 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 17054 W: 2333 L: 2266 D: 12455
Penta | [129, 1599, 5006, 1662, 131]
```
http://chess.grantnet.us/test/35879/

Bench: 3,740,491