### PR TITLE
Use the GNU __int128 extension for mul_hi64()

### DIFF
--- a/src/include/hashkey.h
+++ b/src/include/hashkey.h
@@ -27,15 +27,7 @@ typedef uint64_t hashkey_t;
 // Multiplies two 64-bit unsigned integers and returns the high 64 bits of the result.
 INLINED uint64_t mul_hi64(uint64_t x, uint64_t n)
 {
-    uint64_t xlo = (uint32_t)x;
-    uint64_t xhi = x >> 32;
-    uint64_t nlo = (uint32_t)n;
-    uint64_t nhi = n >> 32;
-    uint64_t c1 = (xlo * nlo) >> 32;
-    uint64_t c2 = (xhi * nlo) + c1;
-    uint64_t c3 = (xlo * nhi) + (uint32_t)c2;
-
-    return xhi * nhi + (c2 >> 32) + (c3 >> 32);
+    return ((unsigned __int128)x * (unsigned __int128)n) >> 64;
 }
 
 // Global table for Zobrist Piece-Square hashes

--- a/src/include/hashkey.h
+++ b/src/include/hashkey.h
@@ -27,7 +27,19 @@ typedef uint64_t hashkey_t;
 // Multiplies two 64-bit unsigned integers and returns the high 64 bits of the result.
 INLINED uint64_t mul_hi64(uint64_t x, uint64_t n)
 {
+#ifdef __SIZEOF_INT128__
     return ((unsigned __int128)x * (unsigned __int128)n) >> 64;
+#else
+    uint64_t xlo = (uint32_t)x;
+    uint64_t xhi = x >> 32;
+    uint64_t nlo = (uint32_t)n;
+    uint64_t nhi = n >> 32;
+    uint64_t c1 = (xlo * nlo) >> 32;
+    uint64_t c2 = (xhi * nlo) + c1;
+    uint64_t c3 = (xlo * nhi) + (uint32_t)c2;
+
+    return xhi * nhi + (c2 >> 32) + (c3 >> 32);
+#endif
 }
 
 // Global table for Zobrist Piece-Square hashes

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.18"
+#define UCI_VERSION "v35.19"
 
 // clang-format off
 


### PR DESCRIPTION
Passed non-regression STC:

```
Elo   | 7.18 +- 5.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 5132 W: 1059 L: 953 D: 3120
Penta | [52, 533, 1333, 553, 95]
```
http://chess.grantnet.us/test/35994/

Bench: 3,740,491