### PR TITLE
Increase reductions if the TT move is non-quiet

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -407,6 +407,7 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
     int ttBound = NO_BOUND;
     score_t ttScore = NO_SCORE;
     move_t ttMove = NO_MOVE;
+    bool ttNoisy = false;
     bool found;
     hashkey_t key = board->stack->boardKey ^ ((hashkey_t)ss->excludedMove << 16);
     TT_Entry *entry = tt_probe(key, &found);
@@ -429,6 +430,8 @@ score_t search(bool pvNode, Board *board, int depth, score_t alpha, score_t beta
 
                 return ttScore;
             }
+
+        ttNoisy = ttMove && is_capture_or_promotion(board, ttMove);
     }
 
     (ss + 2)->killers[0] = (ss + 2)->killers[1] = NO_MOVE;
@@ -709,6 +712,9 @@ main_loop:
 
             // Increase the reduction for cutNodes.
             r += cutNode;
+
+            // Increase the reduction if the TT move is non-quiet.
+            r += ttNoisy;
 
             // Decrease the reduction if the move is a killer or countermove.
             r -= (currmove == mp.killer1 || currmove == mp.killer2 || currmove == mp.counter);

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.19"
+#define UCI_VERSION "v35.20"
 
 // clang-format off
 


### PR DESCRIPTION
Passed STC:

```
Elo   | 2.32 +- 1.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 55534 W: 10894 L: 10523 D: 34117
Penta | [931, 6360, 12886, 6587, 1003]
```
http://chess.grantnet.us/test/36157/

Passed LTC:

```
Elo   | 5.30 +- 3.70 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9046 W: 1279 L: 1141 D: 6626
Penta | [65, 817, 2644, 909, 88]
```
http://chess.grantnet.us/test/36164/

Bench: 3,682,757