### PR TITLE
Add singular negative extensions

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -679,6 +679,14 @@ main_loop:
                 // in the current node, and return a search score early.
                 else if (singularBeta >= beta)
                     return singularBeta;
+
+                // Negative Extensions. If our singular search produced a cutoff,
+                // with singularBeta was too low to beat beta, but the TT entry
+                // having a search score above beta, we assume that searching the
+                // TT move at full depth is futile as we should get a fail-high
+                // deeper on this branch, and reduce its search depth.
+                else if (ttScore >= beta)
+                    extension = -1;
             }
             // Check Extensions. Extend non-LMR searches by one ply for moves
             // that give check.

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.24"
+#define UCI_VERSION "v35.25"
 
 // clang-format off
 


### PR DESCRIPTION
Reduce the search depth of the TT move in MultiCut-like scenarios where
the TT score beats beta, but the singular score doesn't.

Passed STC:

```
Elo   | 2.66 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 36034 W: 6754 L: 6478 D: 22802
Penta | [528, 4045, 8654, 4203, 587]
```
http://chess.grantnet.us/test/36612/

Passed LTC:

```
Elo   | 2.05 +- 1.64 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 44500 W: 5891 L: 5629 D: 32980
Penta | [299, 4112, 13203, 4300, 336]
```
http://chess.grantnet.us/test/36618/

Bench: 3,672,866