### PR TITLE
Fix the initialization of the black attacked-twice bitboard in eval

### DIFF
--- a/src/sources/evaluate.c
+++ b/src/sources/evaluate.c
@@ -300,7 +300,7 @@ void eval_init(const Board *board, const KingPawnEntry *kpe, evaluation_t *eval)
     eval->attackedBy[WHITE][PAWN] = wattacks;
     eval->attackedBy[BLACK][PAWN] = battacks;
     eval->attackedTwice[WHITE] |= eval->attacked[WHITE] & wattacks;
-    eval->attackedTwice[BLACK] |= eval->attacked[BLACK] & wattacks;
+    eval->attackedTwice[BLACK] |= eval->attacked[BLACK] & battacks;
     eval->attackedTwice[WHITE] |= kpe->attacks2[WHITE];
     eval->attackedTwice[BLACK] |= kpe->attacks2[BLACK];
     eval->attacked[WHITE] |= wattacks;

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.26"
+#define UCI_VERSION "v35.27"
 
 // clang-format off
 


### PR DESCRIPTION
Passed non-regression STC:

```
Elo   | 4.77 +- 4.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 7570 W: 1454 L: 1350 D: 4766
Penta | [122, 809, 1827, 897, 130]
```
http://chess.grantnet.us/test/37267/

Bench: 4,139,804