### PR TITLE
Simplify bestmove type scaling in the time manager

### DIFF
--- a/src/include/timeman.h
+++ b/src/include/timeman.h
@@ -46,9 +46,6 @@ typedef enum bestmove_type_e
     BM_TYPE_NB
 } bestmove_type_t;
 
-// Global for scaling time usage based on bestmove type
-extern const double BestmoveTypeScale[BM_TYPE_NB];
-
 // Global for scaling time usage based on stability
 extern const double BestmoveStabilityScale[5];
 

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.27"
+#define UCI_VERSION "v35.28"
 
 // clang-format off
 


### PR DESCRIPTION
Passed non-regression STC:

```
Elo   | 4.42 +- 4.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 7630 W: 1490 L: 1393 D: 4747
Penta | [79, 778, 2035, 813, 110]
```
http://chess.grantnet.us/test/37271/

Passed non-regression LTC:

```
Elo   | 0.41 +- 1.80 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 29754 W: 3995 L: 3960 D: 21799
Penta | [151, 2489, 9558, 2532, 147]
```
http://chess.grantnet.us/test/37272/

Bench: 4,139,804