### PR TITLE
Update the WDL model

### DIFF
--- a/src/include/uci.h
+++ b/src/include/uci.h
@@ -64,7 +64,6 @@ typedef struct _CommandMap
 char *get_next_token(char **str);
 
 const char *move_to_str(move_t move, bool isChess960);
-const char *score_to_str(score_t score);
 move_t str_to_move(const Board *board, const char *str);
 
 // Displays the formatted content while in debug mode.

--- a/src/sources/evaluate.c
+++ b/src/sources/evaluate.c
@@ -388,7 +388,8 @@ scorepair_t evaluate_knights(
     return ret;
 }
 
-scorepair_t evaluate_bishops(const Board *board, evaluation_t *eval, const KingPawnEntry *kpe, color_t us)
+scorepair_t evaluate_bishops(
+    const Board *board, evaluation_t *eval, const KingPawnEntry *kpe, color_t us)
 {
     scorepair_t ret = 0;
     const bitboard_t occupancy = occupancy_bb(board) ^ piece_bb(board, us, QUEEN);

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -741,14 +741,16 @@ main_loop:
             // Perform another search at full depth if LMR failed high.
             if (r != 0 && score > alpha)
             {
-                score = -search(false, board, newDepth + extension, -alpha - 1, -alpha, ss + 1, !cutNode);
+                score = -search(
+                    false, board, newDepth + extension, -alpha - 1, -alpha, ss + 1, !cutNode);
 
                 update_cont_histories(ss, depth, movedPiece, to_sq(currmove), score > alpha);
             }
         }
         // If LMR is not possible, do a search with no reductions.
         else if (!pvNode || moveCount != 1)
-            score = -search(false, board, newDepth + extension, -alpha - 1, -alpha, ss + 1, !cutNode);
+            score =
+                -search(false, board, newDepth + extension, -alpha - 1, -alpha, ss + 1, !cutNode);
 
         // In PV nodes, perform an additional full-window search for the first
         // move, or when all our previous searches returned fail-highs.

--- a/src/sources/timeman.c
+++ b/src/sources/timeman.c
@@ -125,8 +125,7 @@ void timeman_update(Timeman *tm, const Board *board, move_t bestmove, score_t sc
     list_all(&list, board);
 
     // Do we only have one legal move ? Don't burn much time on these.
-    if (movelist_size(&list) == 1)
-        scale = 0.2;
+    if (movelist_size(&list) == 1) scale = 0.2;
 
     // Update bestmove + stability statistics.
     if (tm->prevBestmove != bestmove)

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define UCI_VERSION "v35.29"
+#define UCI_VERSION "v35.30"
 
 // clang-format off
 

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -139,8 +139,8 @@ move_t str_to_move(const Board *board, const char *str)
 void get_winrate_params(const Board *board, double params[2])
 {
     // clang-format off
-    static const double as[4] = {-180.13481505,  541.48089241, -633.47610686,  409.68374895};
-    static const double bs[4] = { -76.66115199,  189.33883856, -129.66753868,  120.80666689};
+    static const double as[4] = {-115.80269028,  326.13955902, -411.17611305,  342.29869813};
+    static const double bs[4] = { -35.81090243,   83.17183837,  -52.14133486,   81.73401953};
     // clang-format on
 
     int material =
@@ -186,8 +186,9 @@ const char *score_to_wdl(score_t score, const Board *board)
     return buf;
 }
 
-const char *score_to_str(score_t score, const Board *board)
+const char *score_to_str(score_t score)
 {
+    static const score_t NormalizeScore = 141;
     static char buf[12];
 
     if (abs(score) >= MATE_FOUND)
@@ -195,13 +196,7 @@ const char *score_to_str(score_t score, const Board *board)
 
     else
     {
-        if (UciOptionFields.normalizeScore && abs(score) < VICTORY)
-        {
-            double params[2];
-
-            get_winrate_params(board, params);
-            score = (score_t)lround(score * 100.0 / params[0]);
-        }
+        if (UciOptionFields.normalizeScore) score = (int32_t)score * 100 / NormalizeScore;
 
         sprintf(buf, "cp %d", score);
     }
@@ -256,7 +251,7 @@ void print_pv(
         imax(depth - !searchedMove, 1),
         rootMove->seldepth,
         multiPv,
-        score_to_str(rootScore, board), BoundStr[bound], score_to_wdl(rootScore, board),
+        score_to_str(rootScore), BoundStr[bound], score_to_wdl(rootScore, board),
         (info_t)nodes,
         (info_t)nps,
         tt_hashfull(),


### PR DESCRIPTION
Make the WDL model use the material value instead of the game ply.

Used 10k selfplay games at 80knpm, using 4moves_noob as the opening book. See https://github.com/official-stockfish/WDL_model for precise information on how the model works.

Bench: 4,139,804

![scoreWDL](https://github.com/mhouppin/stash-bot/assets/45004383/a9f91045-6abd-477a-b909-3d27b542bca3)