### PR TITLE
Remove pawn attacks from the KP table entries

### DIFF
--- a/src/include/pawns.h
+++ b/src/include/pawns.h
@@ -26,11 +26,16 @@ typedef struct _KingPawnEntry
 {
     hashkey_t key;
     bitboard_t attackSpan[COLOR_NB];
-    bitboard_t attacks[COLOR_NB];
-    bitboard_t attacks2[COLOR_NB];
     bitboard_t passed[COLOR_NB];
     scorepair_t value;
 } KingPawnEntry;
+
+// Struct for local pawn eval data
+typedef struct _PawnLocalData
+{
+    bitboard_t attacks[COLOR_NB];
+    bitboard_t attacks2[COLOR_NB];
+} PawnLocalData;
 
 enum
 {

--- a/src/sources/evaluate.c
+++ b/src/sources/evaluate.c
@@ -269,7 +269,7 @@ score_t scale_endgame(const Board *board, const KingPawnEntry *kpe, score_t eg)
     return eg;
 }
 
-void eval_init(const Board *board, const KingPawnEntry *kpe, evaluation_t *eval)
+void eval_init(const Board *board, evaluation_t *eval)
 {
     memset(eval, 0, sizeof(evaluation_t));
 
@@ -294,15 +294,15 @@ void eval_init(const Board *board, const KingPawnEntry *kpe, evaluation_t *eval)
     bitboard_t occupied = occupancy_bb(board);
     bitboard_t wpawns = piece_bb(board, WHITE, PAWN);
     bitboard_t bpawns = piece_bb(board, BLACK, PAWN);
-    bitboard_t wattacks = kpe->attacks[WHITE];
-    bitboard_t battacks = kpe->attacks[BLACK];
+    bitboard_t wattacks = wpawns_attacks_bb(wpawns);
+    bitboard_t battacks = bpawns_attacks_bb(bpawns);
 
     eval->attackedBy[WHITE][PAWN] = wattacks;
     eval->attackedBy[BLACK][PAWN] = battacks;
     eval->attackedTwice[WHITE] |= eval->attacked[WHITE] & wattacks;
     eval->attackedTwice[BLACK] |= eval->attacked[BLACK] & battacks;
-    eval->attackedTwice[WHITE] |= kpe->attacks2[WHITE];
-    eval->attackedTwice[BLACK] |= kpe->attacks2[BLACK];
+    eval->attackedTwice[WHITE] |= wpawns_2attacks_bb(wpawns);
+    eval->attackedTwice[BLACK] |= bpawns_2attacks_bb(bpawns);
     eval->attacked[WHITE] |= wattacks;
     eval->attacked[BLACK] |= battacks;
 
@@ -811,8 +811,8 @@ score_t evaluate(const Board *board)
     KingPawnEntry *kpe;
     score_t mg, eg, score;
 
+    eval_init(board, &eval);
     kpe = kp_probe(board);
-    eval_init(board, kpe, &eval);
 
     // Add the King-Pawn structure evaluation.
     tapered += kpe->value;


### PR DESCRIPTION
Since pawn attacks are relatively easy to compute, remove those from the KingPawnEntry struct, bringing down the King-Pawn hashtable size from 2.5 MiB to 1.5 MiB.

Passed non-regression STC:

```
Elo   | 0.50 +- 2.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 29324 W: 5560 L: 5518 D: 18246
Penta | [285, 2874, 8304, 2912, 287]
```
http://chess.grantnet.us/test/37323/

Bench: 4,139,804