### PR TITLE
Clarify examples in `score_difference_scale`

### DIFF
--- a/src/sources/timeman.c
+++ b/src/sources/timeman.c
@@ -106,11 +106,11 @@ double score_difference_scale(score_t s)
     // Clamp score to the range [-100, 100], and convert it to a time scale in
     // the range [0.5, 2.0].
     // Examples:
-    // -100 -> 2.000x time
-    //  -50 -> 1.414x time
+    // -100 -> 0.500x time
+    //  -50 -> 0.707x time
     //    0 -> 1.000x time
-    //  +50 -> 0.707x time
-    // +100 -> 0.500x time
+    //  +50 -> 1.414x time
+    // +100 -> 2.000x time
     return pow(T, iclamp(s, -X, X) / (double)X);
 }
 


### PR DESCRIPTION
Since `score_difference_scale` is expected to be invoked using `prevScore - currentScore`, I believe the scores in the comment examples are reversed, given that a negative diff represents a score improvement and therefore less time allocated.

Let me know if I'm reading it wrong.

----

I accidentally opened a merge request in GitLab fork first, I was confused about what's a mirror of what