### PR TITLE
Fix the depth counter being off by one for partial searches

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -149,7 +149,7 @@ static void print_pv(
     string_init(&info_str);
     string_reserve(&info_str, 2048);
     string_push_back_strview(&info_str, STATIC_STRVIEW("info depth "));
-    string_push_back_u64(&info_str, depth);
+    string_push_back_u64(&info_str, u16_max(depth - !searched, 1));
     string_push_back_strview(&info_str, STATIC_STRVIEW(" seldepth "));
     string_push_back_u64(&info_str, root_move->seldepth);
     string_push_back_strview(&info_str, STATIC_STRVIEW(" multipv "));

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v36.11"
+#define UCI_VERSION "v36.12"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
Correct the depth reported in info lines when the search has been interrupted mid-iteration, or in MultiPV scenarios when some lines have not been searched yet to the current root depth.

Bench: 4,123,356