### PR TITLE
Fix ponderhit not stopping the search

### DIFF
--- a/src/include/bitboard.h
+++ b/src/include/bitboard.h
@@ -53,7 +53,7 @@ static const Bitboard CENTER_FILES_BB = U64(0x3C3C3C3C3C3C3C3C);
 static const Bitboard CENTER_BB = U64(0x0000001818000000);
 
 // The structure used for magic bitboards
-typedef struct _Magic {
+typedef struct {
     Bitboard mask;
     Bitboard magic;
     Bitboard *moves;

--- a/src/include/board.h
+++ b/src/include/board.h
@@ -26,7 +26,7 @@
 #include "strview.h"
 
 // Struct representing the board stack data from past moves
-typedef struct _Boardstack {
+typedef struct Boardstack {
     Key board_key;
     Key king_pawn_key;
     Key material_key;
@@ -34,7 +34,7 @@ typedef struct _Boardstack {
     Bitboard king_blockers[COLOR_NB];
     Bitboard pinners[COLOR_NB];
     Bitboard check_squares[PIECETYPE_NB];
-    struct _Boardstack *previous;
+    struct Boardstack *previous;
     CastlingRights castlings;
     u16 rule50;
     i16 repetition;
@@ -45,7 +45,7 @@ typedef struct _Boardstack {
 } Boardstack;
 
 // Struct representing the board
-typedef struct _Board {
+typedef struct {
     Piece mailbox[SQUARE_NB];
     Bitboard piecetype_bb[PIECETYPE_NB];
     Bitboard color_bb[COLOR_NB];

--- a/src/include/endgame.h
+++ b/src/include/endgame.h
@@ -56,7 +56,7 @@ typedef Score (*EndgameScoreFn)(const Board *, Color);
 typedef Scalefactor (*EndgameScaleFn)(const Board *, Color);
 
 // Struct holding a specialized endgame
-typedef struct _EndgameEntry {
+typedef struct {
     Key key;
     EndgameScoreFn score_fn;
     EndgameScaleFn scale_fn;

--- a/src/include/evaluate.h
+++ b/src/include/evaluate.h
@@ -28,7 +28,7 @@ enum {
     ENDGAME_COUNT = 4
 };
 
-typedef enum _TuneIndex {
+typedef enum {
     IDX_PIECE,
     IDX_PSQT = IDX_PIECE + 5,
     IDX_INITIATIVE = IDX_PSQT + 48 + 32 * 5,
@@ -92,7 +92,7 @@ typedef enum _TuneIndex {
     IDX_COUNT
 } TuneIndex;
 
-typedef struct _EvalTrace {
+typedef struct {
     i16 phase;
     Scorepair tapered_eval;
     Scorepair safety_eval[COLOR_NB];
@@ -100,7 +100,7 @@ typedef struct _EvalTrace {
     i8 coeffs[IDX_COUNT][COLOR_NB];
 } EvalTrace;
 
-typedef struct _EvaluationData {
+typedef struct {
     Bitboard king_zone[COLOR_NB];
     Bitboard mobility_zone[COLOR_NB];
     Bitboard attacked[COLOR_NB];

--- a/src/include/history.h
+++ b/src/include/history.h
@@ -41,7 +41,7 @@ INLINED void update_hist_entry(i16 *entry, i16 bonus) {
     *entry += bonus - (i32)*entry * (i32)i32_abs(bonus) / HISTORY_MAX;
 }
 
-typedef struct _ButterflyHistory {
+typedef struct {
     i16 data[COLOR_NB][SQUARE_NB * SQUARE_NB];
 } ButterflyHistory;
 
@@ -53,15 +53,15 @@ INLINED i16 butterfly_hist_score(const ButterflyHistory *hist, Piece piece, Move
     return hist->data[piece_color(piece)][move_square_mask(move)];
 }
 
-typedef struct _PieceHistory {
+typedef struct {
     i16 data[PIECE_NB][SQUARE_NB];
 } PieceHistory;
 
-typedef struct _ContinuationHistory {
+typedef struct {
     PieceHistory piece_history[PIECE_NB][SQUARE_NB];
 } ContinuationHistory;
 
-typedef struct _CountermoveHistory {
+typedef struct {
     Move data[PIECE_NB][SQUARE_NB];
 } CountermoveHistory;
 
@@ -73,7 +73,7 @@ INLINED i16 piece_hist_score(const PieceHistory *hist, Piece piece, Square to) {
     return hist->data[piece][to];
 }
 
-typedef struct _CaptureHistory {
+typedef struct {
     i16 data[PIECE_NB][SQUARE_NB][PIECETYPE_NB];
 } CaptureHistory;
 
@@ -92,7 +92,7 @@ INLINED i16
     return hist->data[piece][to][captured];
 }
 
-typedef struct _CorrectionHistory {
+typedef struct {
     i16 data[COLOR_NB][CORRECTION_HISTORY_ENTRY_NB];
 } CorrectionHistory;
 

--- a/src/include/kp_eval.h
+++ b/src/include/kp_eval.h
@@ -26,19 +26,19 @@ enum {
 };
 
 // Struct for pawn eval data
-typedef struct _KingPawnEntry {
+typedef struct {
     Key key;
     Bitboard attack_span[COLOR_NB];
     Bitboard passed[COLOR_NB];
     Scorepair value;
 } KingPawnEntry;
 
-typedef struct _KingPawnTable {
+typedef struct {
     KingPawnEntry entry[KING_PAWN_ENTRY_NB];
 } KingPawnTable;
 
 // Struct for local pawn eval data
-typedef struct _PawnLocalData {
+typedef struct {
     Bitboard attacks[COLOR_NB];
     Bitboard attacks2[COLOR_NB];
 } PawnLocalData;

--- a/src/include/kpk_bitbase.h
+++ b/src/include/kpk_bitbase.h
@@ -34,7 +34,7 @@ enum {
     KPK_WIN = 4
 };
 
-typedef struct _KpkPosition {
+typedef struct {
     Square ksq[COLOR_NB];
     Square psq;
     Color stm;

--- a/src/include/movelist.h
+++ b/src/include/movelist.h
@@ -25,13 +25,13 @@
 #include "hashkey.h"
 
 // Structure for holding moves along with their score
-typedef struct _ExtendedMove {
+typedef struct {
     Move move;
     i32 score;
 } ExtendedMove;
 
 // Structure for holding a list of moves
-typedef struct _Movelist {
+typedef struct {
     ExtendedMove moves[MAX_MOVES];
     ExtendedMove *end;
 } Movelist;

--- a/src/include/movepicker.h
+++ b/src/include/movepicker.h
@@ -23,7 +23,7 @@
 #include "worker.h"
 
 // Enum for the various stages of the move picker
-typedef enum _MovepickerStage {
+typedef enum {
     PICK_TT,
     GEN_NOISY,
     PICK_GOOD_NOISY,
@@ -40,7 +40,7 @@ typedef enum _MovepickerStage {
 } MovepickerStage;
 
 // Struct for the move picker
-typedef struct _Movepicker {
+typedef struct {
     Movelist list;
     ExtendedMove *current;
     ExtendedMove *bad_captures;

--- a/src/include/option.h
+++ b/src/include/option.h
@@ -24,7 +24,7 @@
 #include "strmanip.h"
 
 // Enum for supported option types
-typedef enum _OptionType {
+typedef enum {
     OptionButton,
     OptionSpinInteger,
     OptionSpinFloat,
@@ -37,10 +37,10 @@ typedef enum _OptionType {
     OPTION_TYPE_COUNT,
 } OptionType;
 
-typedef struct _OptButtonParams {
+typedef struct {
 } OptButtonParams;
 
-typedef struct _OptSpinIntegerParams {
+typedef struct {
     i64 *current_value;
     i64 default_value;
     i64 min_value;
@@ -48,7 +48,7 @@ typedef struct _OptSpinIntegerParams {
     bool is_tunable;
 } OptSpinIntegerParams;
 
-typedef struct _OptSpinFloatParams {
+typedef struct {
     f64 *current_value;
     f64 default_value;
     f64 min_value;
@@ -57,24 +57,24 @@ typedef struct _OptSpinFloatParams {
     bool is_tunable;
 } OptSpinFloatParams;
 
-typedef struct _OptCheckParams {
+typedef struct {
     bool *current_value;
     bool default_value;
 } OptCheckParams;
 
-typedef struct _OptStringParams {
+typedef struct {
     String *current_value;
     String default_value;
 } OptStringParams;
 
-typedef struct _OptComboParams {
+typedef struct {
     String *current_value;
     String default_value;
     String *allowed_values;
     usize allowed_count;
 } OptComboParams;
 
-typedef struct _OptScoreParams {
+typedef struct {
     Score *current_value;
     Score default_value;
     Score min_value;
@@ -82,7 +82,7 @@ typedef struct _OptScoreParams {
     bool is_tunable;
 } OptScoreParams;
 
-typedef struct _OptHalfScorepairParams {
+typedef struct {
     Scorepair *current_value;
     Score default_value;
     Score min_value;
@@ -91,7 +91,7 @@ typedef struct _OptHalfScorepairParams {
     bool is_tunable;
 } OptHalfScorepairParams;
 
-typedef union _OptionParams {
+typedef union {
     OptButtonParams button;
     OptSpinIntegerParams spin_integer;
     OptSpinFloatParams spin_float;
@@ -102,14 +102,14 @@ typedef union _OptionParams {
     OptHalfScorepairParams half_scorepair;
 } OptionParams;
 
-typedef struct _OptionVtable {
+typedef struct {
     void (*option_show)(StringView, const OptionParams *);
     void (*option_show_tune)(StringView, const OptionParams *);
     bool (*option_try_set)(OptionParams *, StringView);
     void (*option_dtor)(OptionParams *);
 } OptionVtable;
 
-typedef struct _Option {
+typedef struct {
     String option_name;
     OptionType option_type;
     const OptionVtable *option_vtable;
@@ -118,13 +118,11 @@ typedef struct _Option {
     void *callback_data;
 } Option;
 
-typedef struct _OptionList {
+typedef struct {
     Option *options;
     usize size;
     usize capacity;
 } OptionList;
-
-// TODO: tuning macros are missing.
 
 #define TUNE_INT(name, minval, maxval) \
     do { \

--- a/src/include/search.h
+++ b/src/include/search.h
@@ -24,7 +24,7 @@
 void search_init(void);
 
 // Struct for holding search data
-typedef struct _Searchstack {
+typedef struct {
     i16 plies;
     i16 double_extensions;
     Score static_eval;

--- a/src/include/search_params.h
+++ b/src/include/search_params.h
@@ -23,7 +23,7 @@
 #include "movelist.h"
 #include "strview.h"
 
-typedef struct _SearchParams {
+typedef struct {
     i64 move_overhead;
     i64 multi_pv;
     bool show_wdl;

--- a/src/include/strmanip.h
+++ b/src/include/strmanip.h
@@ -24,7 +24,7 @@
 
 static const usize STRING_MIN_ALLOC = 16;
 
-typedef struct _String {
+typedef struct {
     u8 *data;
     usize size;
     usize capacity;

--- a/src/include/strview.h
+++ b/src/include/strview.h
@@ -33,7 +33,7 @@ INLINED usize cstr_length(const char *cstr) {
     return i;
 }
 
-typedef struct _StringView {
+typedef struct {
     const u8 *data;
     usize size;
 } StringView;

--- a/src/include/timeman.h
+++ b/src/include/timeman.h
@@ -25,14 +25,14 @@
 #include "search_params.h"
 
 // Enum for the type of time management to use
-typedef enum _TimemanMode {
+typedef enum {
     TmNone,
     TmMovetime,
     TmTournament,
 } TimemanMode;
 
 // Struct for time management
-typedef struct _Timeman {
+typedef struct {
     Timepoint start;
     TimemanMode mode;
     bool pondering;
@@ -63,10 +63,21 @@ void timeman_update(
     Score root_score
 );
 
+// Forward declaration required to avoid cyclic include paths.
+struct WorkerPool;
+
 // Checks if the time manager thinks we have spent enough time in search
-bool timeman_can_stop_search(const Timeman *timeman, Timepoint current_tp);
+bool timeman_can_stop_search(
+    const Timeman *timeman,
+    const struct WorkerPool *wpool,
+    Timepoint current_tp
+);
 
 // Checks if the time manager says we must interrupt the search now
-bool timeman_must_stop_search(const Timeman *timeman, Timepoint current_tp);
+bool timeman_must_stop_search(
+    const Timeman *timeman,
+    const struct WorkerPool *wpool,
+    Timepoint current_tp
+);
 
 #endif

--- a/src/include/tt.h
+++ b/src/include/tt.h
@@ -30,7 +30,7 @@ enum {
     GENERATION_CYCLE = 256 + GENERATION_SHIFT - 1,
 };
 
-typedef struct _TranspositionEntry {
+typedef struct {
     Key key;
     Score score;
     Score eval;
@@ -48,7 +48,7 @@ INLINED Bound tt_entry_bound(const TranspositionEntry *tt_entry) {
     return (Bound)(tt_entry->genbound & ~GENERATION_MASK);
 }
 
-typedef struct _TranspositionCluster {
+typedef struct {
     TranspositionEntry cluster_entry[ENTRY_CLUSTER_SIZE];
 } TranspositionCluster;
 
@@ -58,7 +58,7 @@ static_assert(
     "Clusters are not aligned to cache boundaries"
 );
 
-typedef struct _TranspositionTable {
+typedef struct {
     usize cluster_count;
     TranspositionCluster *table;
     u8 generation;

--- a/src/include/tuner.h
+++ b/src/include/tuner.h
@@ -37,7 +37,7 @@ f64 sigmoid(f64 k, f64 eval);
 
 f64 lerp(f64 lo, f64 hi, f64 rate);
 
-typedef struct _TunerConfig {
+typedef struct {
     usize threads;
     usize iterations;
     usize display_every;
@@ -52,23 +52,23 @@ typedef struct _TunerConfig {
 
 void tuner_config_set_default_values(TunerConfig *tuner_config);
 
-typedef struct _TupleVector {
+typedef struct {
     f64 values[IDX_COUNT][2];
 } TupleVector;
 
 void tp_vector_reset(TupleVector *tp_vector);
 
-typedef struct _TupleSafetyEval {
+typedef struct {
     f64 values[COLOR_NB][PHASE_NB];
 } TupleSafetyEval;
 
-typedef struct _TunerTuple {
+typedef struct {
     u16 index;
     i8 wcoeff;
     i8 bcoeff;
 } TunerTuple;
 
-typedef struct _TunerEntry {
+typedef struct {
     Score static_eval;
     Score search_score;
     Scorepair tapered_eval;
@@ -100,7 +100,7 @@ void tuner_entry_update_gradient(
     f64 sigmoid_k
 );
 
-typedef struct _TunerDataset {
+typedef struct {
     TunerEntry *entries;
     usize size;
     usize capacity;
@@ -135,7 +135,7 @@ void tuner_dataset_compute_gradient(
     usize batch_index
 );
 
-typedef struct _AdamOptimizer {
+typedef struct {
     TupleVector gradient;
     TupleVector momentum;
     TupleVector velocity;
@@ -158,7 +158,7 @@ void adam_do_one_iteration(
     f64 sigmoid_k
 );
 
-typedef enum _DisplayType {
+typedef enum {
     TypeScorepair,
     TypeScorepairArray,
     TypeRawString,
@@ -166,7 +166,7 @@ typedef enum _DisplayType {
     TypeCustom,
 } DisplayType;
 
-typedef struct _DisplayScorepair {
+typedef struct {
     String name;
     u16 index;
     u16 name_alignment;
@@ -179,7 +179,7 @@ void disp_scorepair_show(
     const TupleVector *delta
 );
 
-typedef struct _DisplayScorepairArray {
+typedef struct {
     String name;
     u16 index;
     u16 array_size;
@@ -196,27 +196,27 @@ void disp_sp_array_show(
     const TupleVector *delta
 );
 
-typedef struct _DisplayRawString {
+typedef struct {
     String str;
 } DisplayRawString;
 
-typedef struct _DisplayCustomData {
+typedef struct {
     void (*custom_display)(const TupleVector *, const TupleVector *);
 } DisplayCustomData;
 
-typedef union _DisplayUnion {
+typedef union {
     DisplayScorepair scorepair;
     DisplayScorepairArray scorepair_array;
     DisplayRawString raw_string;
     DisplayCustomData custom;
 } DisplayUnion;
 
-typedef struct _DisplayBlock {
+typedef struct {
     DisplayType block_type;
     DisplayUnion data_union;
 } DisplayBlock;
 
-typedef struct _DisplaySequence {
+typedef struct {
     DisplayBlock *blocks;
     usize size;
     usize capacity;

--- a/src/include/uci.h
+++ b/src/include/uci.h
@@ -25,7 +25,7 @@
 #include "strview.h"
 #include "worker.h"
 
-typedef struct _OptionValues {
+typedef struct {
     i64 threads;
     i64 hash;
     i64 move_overhead;
@@ -36,14 +36,14 @@ typedef struct _OptionValues {
     bool normalize_score;
 } OptionValues;
 
-typedef struct _Uci {
+typedef struct {
     OptionValues option_values;
     OptionList option_list;
     Board root_board;
     WorkerPool worker_pool;
 } Uci;
 
-typedef struct _Command {
+typedef struct {
     StringView cmd_name;
     void (*cmd_exec)(Uci *, StringView);
 } Command;

--- a/src/include/wdl.h
+++ b/src/include/wdl.h
@@ -24,13 +24,13 @@
 
 // The structure that holds the parameters for WDL estimation.
 // See https://github.com/official-stockfish/WDL_model
-typedef struct _WdlParams {
+typedef struct {
     f64 mean;
     f64 spread;
 } WdlParams;
 
 // The structure that holds the WDL estimation
-typedef struct _WdlValue {
+typedef struct {
     u16 win;
     u16 draw;
     u16 loss;

--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -30,10 +30,10 @@
 #include "tt.h"
 
 // Early declaration required for the worker struct
-struct _WorkerPool;
+struct WorkerPool;
 
 // Struct for PV lines
-typedef struct _PvLine {
+typedef struct {
     Move moves[MAX_MOVES];
     u16 length;
 } PvLine;
@@ -48,7 +48,7 @@ void pv_line_init_move(PvLine *pv_line, Move move);
 void pv_line_update(PvLine *restrict pv_line, Move bestmove, const PvLine *restrict next);
 
 // Struct for root moves
-typedef struct _RootMove {
+typedef struct {
     Move move;
     u16 seldepth;
     Score previous_score;
@@ -66,9 +66,9 @@ RootMove *find_root_move(RootMove *root_moves, usize root_count, Move move);
 void sort_root_moves(RootMove *root_moves, usize root_count);
 
 // Struct for worker thread data
-typedef struct _Worker {
+typedef struct {
     Board board;
-    struct _WorkerPool *pool;
+    struct WorkerPool *pool;
     ButterflyHistory *butterfly_hist;
     ContinuationHistory *continuation_hist;
     CountermoveHistory *counter_hist;
@@ -114,7 +114,7 @@ INLINED void worker_increment_nodes(Worker *worker) {
 }
 
 // Initializes the worker
-void worker_init(Worker *worker, usize thread_index, struct _WorkerPool *wpool);
+void worker_init(Worker *worker, usize thread_index, struct WorkerPool *wpool);
 
 // Frees all memory associated with the worker
 void worker_destroy(Worker *worker);
@@ -134,7 +134,7 @@ void worker_wait_search_completion(Worker *worker);
 // Entry point for the worker thread main loop
 void *worker_entry_point(void *worker_ptr);
 
-typedef struct _WorkerPool {
+typedef struct WorkerPool {
     pthread_attr_t worker_pthread_attr;
     usize worker_count;
     Worker **worker_list;

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -347,7 +347,7 @@ void worker_search(Worker *worker) {
 
             // If we went over optimal time usage, we just finished our iteration, so we can safely
             // stop search.
-            if (timeman_can_stop_search(&worker->pool->timeman, timepoint_now())) {
+            if (timeman_can_stop_search(&worker->pool->timeman, worker->pool, timepoint_now())) {
                 break;
             }
         }

--- a/src/sources/syncio.c
+++ b/src/sources/syncio.c
@@ -36,6 +36,8 @@ void sync_init(void) {
         perror("Unable to initialize stdout mutex");
         exit(EXIT_FAILURE);
     }
+
+    atomic_init(&UciDebug, false);
 }
 
 void sync_lock_stdout(void) {

--- a/src/sources/timeman.c
+++ b/src/sources/timeman.c
@@ -22,6 +22,7 @@
 
 #include "movelist.h"
 #include "syncio.h"
+#include "worker.h"
 
 // Scaling table based on the number of consecutive iterations the bestmove held
 const f64 BestmoveStabilityScale[5] = {2.50, 1.20, 0.90, 0.80, 0.75};
@@ -155,8 +156,12 @@ void timeman_update(
     info_debug("info string optimal_time " FORMAT_LARGE_INT "\n", (LargeInt)timeman->optimal_time);
 }
 
-bool timeman_can_stop_search(const Timeman *timeman, Timepoint current_tp) {
-    if (timeman->pondering && /* wpool_is_pondering(&SearchWorkerPool) */ true) {
+bool timeman_can_stop_search(
+    const Timeman *timeman,
+    const struct WorkerPool *wpool,
+    Timepoint current_tp
+) {
+    if (timeman->pondering && wpool_is_pondering(wpool)) {
         return false;
     }
 
@@ -164,8 +169,12 @@ bool timeman_can_stop_search(const Timeman *timeman, Timepoint current_tp) {
         && timepoint_diff(timeman->start, current_tp) >= timeman->optimal_time;
 }
 
-bool timeman_must_stop_search(const Timeman *timeman, Timepoint current_tp) {
-    if (timeman->pondering && /* wpool_is_pondering(&SearchWorkerPool) */ true) {
+bool timeman_must_stop_search(
+    const Timeman *timeman,
+    const struct WorkerPool *wpool,
+    Timepoint current_tp
+) {
+    if (timeman->pondering && wpool_is_pondering(wpool)) {
         return false;
     }
 

--- a/src/sources/tuner.c
+++ b/src/sources/tuner.c
@@ -909,7 +909,10 @@ void init_disp_sequence_and_base_values(
     TUNE_ADD_SP_ARRAY(RookMobility, IDX_MOBILITY_ROOK, 15, 0, 15, 4, 4, true);
     TUNE_ADD_SP_ARRAY(QueenMobility, IDX_MOBILITY_QUEEN, 28, 0, 28, 4, 4, true);
 
-    disp_sequence_add_raw_string(disp_sequence, STATIC_STRVIEW("// King Safety linear eval terms\n"));
+    disp_sequence_add_raw_string(
+        disp_sequence,
+        STATIC_STRVIEW("// King Safety linear eval terms\n")
+    );
     TUNE_ADD_SCOREPAIR(FarKnight, IDX_FAR_KNIGHT, 9, 3);
     TUNE_ADD_SCOREPAIR(FarBishop, IDX_FAR_BISHOP, 9, 3);
     TUNE_ADD_SCOREPAIR(FarRook, IDX_FAR_ROOK, 9, 3);

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v36.13"
+#define UCI_VERSION "v36.14"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
Add a check in the time manager for ponderhit being sent to the worker pool. Additionally, fix some issues with structs/enums/unions using reserved identifiers, and some potential UB on atomics not being properly initialized.

Bench: 4,123,356