### PR TITLE
Avoid playing some noisy moves twice if they end up being killers

### DIFF
--- a/src/sources/movepicker.c
+++ b/src/sources/movepicker.c
@@ -183,6 +183,7 @@ top:
 
             // Don't play the same move twice.
             if (mp->killer1 != NO_MOVE && mp->killer1 != mp->tt_move
+                && !board_move_is_noisy(mp->board, mp->killer1)
                 && board_move_is_pseudolegal(mp->board, mp->killer1)) {
                 return mp->killer1;
             }
@@ -194,6 +195,7 @@ top:
 
             // Don't play the same move twice.
             if (mp->killer2 != NO_MOVE && mp->killer2 != mp->tt_move && mp->killer2 != mp->killer1
+                && !board_move_is_noisy(mp->board, mp->killer2)
                 && board_move_is_pseudolegal(mp->board, mp->killer2)) {
                 return mp->killer2;
             }
@@ -206,6 +208,7 @@ top:
             // Don't play the same move twice.
             if (mp->counter != NO_MOVE && mp->counter != mp->tt_move && mp->counter != mp->killer1
                 && mp->counter != mp->killer2
+                && !board_move_is_noisy(mp->board, mp->counter)
                 && board_move_is_pseudolegal(mp->board, mp->counter)) {
                 return mp->counter;
             }

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v36.14"
+#define UCI_VERSION "v36.15"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
Passed STC:

```
Elo   | 4.12 +- 3.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16686 W: 3276 L: 3078 D: 10332
Penta | [269, 1865, 3895, 2027, 287]
```
http://chess.grantnet.us/test/38863/

Passed LTC:

```
Elo   | 9.01 +- 5.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4708 W: 700 L: 578 D: 3430
Penta | [28, 421, 1354, 503, 48]
```
http://chess.grantnet.us/test/38868/

Bench: 4,247,647