### PR TITLE
Allow singular searches to extend quiet TT moves by 3 plies

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -832,7 +832,7 @@ main_loop:
                 if (singular_score < singular_beta) {
                     if (!pv_node && singular_beta - singular_score > 14
                         && ss->double_extensions <= 10) {
-                        extension = 2;
+                        extension = 2 + (!tt_noisy && singular_beta - singular_score > 120);
                         ++ss->double_extensions;
                     } else {
                         extension = 1;

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v36.15"
+#define UCI_VERSION "v36.16"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
Passed STC:

```
Elo   | 1.84 +- 1.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 134604 W: 26002 L: 25290 D: 83312
Penta | [2137, 15614, 31308, 15886, 2357]
```
http://chess.grantnet.us/test/38945/

Passed LTC:

```
Elo   | 2.04 +- 1.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 46908 W: 6491 L: 6215 D: 34202
Penta | [364, 4438, 13601, 4660, 391]
```
http://chess.grantnet.us/test/38947/

Bench: 4,856,524