### PR TITLE
Add non-pawn correction history

### DIFF
--- a/src/include/board.h
+++ b/src/include/board.h
@@ -30,6 +30,7 @@ typedef struct Boardstack {
     Key board_key;
     Key king_pawn_key;
     Key material_key;
+    Key nonpawn_key[COLOR_NB];
     Bitboard checkers;
     Bitboard king_blockers[COLOR_NB];
     Bitboard pinners[COLOR_NB];
@@ -235,6 +236,10 @@ INLINED bool board_move_is_noisy(const Board *board, Move move) {
 INLINED Key board_pawn_key(const Board *board) {
     return board->stack->king_pawn_key ^ ZobristPsq[WHITE_KING][board_king_square(board, WHITE)]
         ^ ZobristPsq[BLACK_KING][board_king_square(board, BLACK)];
+}
+
+INLINED Key board_nonpawn_key(const Board *board, Color color) {
+    return board->stack->nonpawn_key[color];
 }
 
 // Helper function for grabbing a material count with standardized values: Pawn=1, Knight=Bishop=3,

--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -73,7 +73,8 @@ typedef struct {
     ContinuationHistory *continuation_hist;
     CountermoveHistory *counter_hist;
     CaptureHistory *capture_hist;
-    CorrectionHistory *correction_hist;
+    CorrectionHistory *pawn_corrhist;
+    CorrectionHistory *nonpawn_corrhist;
     KingPawnTable *king_pawn_table;
 
     u16 seldepth;

--- a/src/sources/tuner.c
+++ b/src/sources/tuner.c
@@ -371,7 +371,8 @@ void tuner_dataset_start_session(TunerDataset *tuner_dataset, const TunerConfig 
 
         printf("Iteration [" FORMAT_LARGE_INT "], Loss [%.7lf]\n", (LargeInt)iteration, loss);
 
-        if ((iteration + 1) % tuner_config->display_every == 0 || iteration + 1 == tuner_config->iterations) {
+        if ((iteration + 1) % tuner_config->display_every == 0
+            || iteration + 1 == tuner_config->iterations) {
             disp_sequence_show(&disp_sequence, &base, &delta);
         }
 

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v36.20"
+#define UCI_VERSION "v36.21"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},

--- a/src/sources/worker.c
+++ b/src/sources/worker.c
@@ -91,7 +91,8 @@ void worker_init(Worker *worker, usize thread_index, struct WorkerPool *pool) {
     worker->continuation_hist = wrap_aligned_alloc(64, sizeof(ContinuationHistory));
     worker->counter_hist = wrap_aligned_alloc(64, sizeof(CountermoveHistory));
     worker->capture_hist = wrap_aligned_alloc(64, sizeof(CaptureHistory));
-    worker->correction_hist = wrap_aligned_alloc(64, sizeof(CorrectionHistory));
+    worker->pawn_corrhist = wrap_aligned_alloc(64, sizeof(CorrectionHistory));
+    worker->nonpawn_corrhist = wrap_aligned_alloc(64, sizeof(CorrectionHistory) * COLOR_NB);
     worker->king_pawn_table = wrap_aligned_alloc(64, sizeof(KingPawnTable));
     worker->root_moves = wrap_malloc(sizeof(RootMove) * MAX_MOVES);
     worker->must_exit = false;
@@ -134,7 +135,8 @@ void worker_destroy(Worker *worker) {
     wrap_aligned_free(worker->continuation_hist);
     wrap_aligned_free(worker->counter_hist);
     wrap_aligned_free(worker->capture_hist);
-    wrap_aligned_free(worker->correction_hist);
+    wrap_aligned_free(worker->pawn_corrhist);
+    wrap_aligned_free(worker->nonpawn_corrhist);
     wrap_aligned_free(worker->king_pawn_table);
     free(worker->root_moves);
 }
@@ -144,7 +146,8 @@ void worker_init_new_game(Worker *worker) {
     memset(worker->continuation_hist, 0, sizeof(ContinuationHistory));
     memset(worker->counter_hist, 0, sizeof(CountermoveHistory));
     memset(worker->capture_hist, 0, sizeof(CaptureHistory));
-    memset(worker->correction_hist, 0, sizeof(CorrectionHistory));
+    memset(worker->pawn_corrhist, 0, sizeof(CorrectionHistory));
+    memset(worker->nonpawn_corrhist, 0, sizeof(CorrectionHistory) * COLOR_NB);
     memset(worker->king_pawn_table, 0, sizeof(KingPawnTable));
 }
 


### PR DESCRIPTION
Huge thanks to @TheRealGioviok for suggesting this.

Passed STC:
```
Elo   | 26.33 +- 9.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1798 W: 412 L: 276 D: 1110
Penta | [15, 179, 411, 243, 51]
```
http://chess.grantnet.us/test/39039/

Passed LTC:
```
Elo   | 27.37 +- 9.37 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1450 W: 255 L: 141 D: 1054
Penta | [7, 102, 410, 182, 24]
```
http://chess.grantnet.us/test/39040/

Bench: 4,646,465