### PR TITLE
Make the board state more compact

### DIFF
--- a/src/include/board.h
+++ b/src/include/board.h
@@ -36,7 +36,7 @@ typedef struct Boardstack {
     Bitboard pinners[COLOR_NB];
     Bitboard check_squares[PIECETYPE_NB];
     struct Boardstack *previous;
-    CastlingRights castlings;
+    CastlingMask castlings;
     u16 rule50;
     i16 repetition;
     u16 plies_since_nullmove;
@@ -51,7 +51,7 @@ typedef struct {
     Bitboard piecetype_bb[PIECETYPE_NB];
     Bitboard color_bb[COLOR_NB];
     u8 piece_count[PIECE_NB];
-    CastlingRights castling_mask[SQUARE_NB];
+    CastlingMask castling_mask[SQUARE_NB];
     Square castling_rook_square[CASTLING_NB];
     Bitboard castling_path[CASTLING_NB];
     Boardstack *stack;
@@ -222,7 +222,7 @@ INLINED Bitboard board_king_square(const Board *board, Color color) {
 }
 
 // Checks if the given castling has an obstructed path
-INLINED bool board_castling_is_blocked(const Board *board, CastlingRights castling) {
+INLINED bool board_castling_is_blocked(const Board *board, CastlingRight castling) {
     return !!(board_occupancy_bb(board) & board->castling_path[castling]);
 }
 

--- a/src/include/chess_types.h
+++ b/src/include/chess_types.h
@@ -273,31 +273,58 @@ INLINED Direction pawn_direction(Color color)
     return color == WHITE ? NORTH : SOUTH;
 }
 
-typedef u8 CastlingRights;
+typedef u8 CastlingRight;
+typedef u8 CastlingMask;
 
 enum
 {
-    WHITE_OO = 1,
-    WHITE_OOO = 2,
-    WHITE_CASTLING = 3,
-    BLACK_OO = 4,
-    KINGSIDE_CASTLING = 5,
-    BLACK_OOO = 8,
-    QUEENSIDE_CASTLING = 10,
-    BLACK_CASTLING = 12,
-    ANY_CASTLING = 15,
-    CASTLING_NB = 16
+    WHITE_OO = 0,
+    WHITE_OOO = 1,
+    BLACK_OO = 2,
+    BLACK_OOO = 3,
+    CASTLING_NB = 4
 };
 
-INLINED bool cr_is_valid(CastlingRights cr)
+enum
 {
-    return cr < CASTLING_NB;
+    WHITE_OO_MASK = 1,
+    WHITE_OOO_MASK = 2,
+    WHITE_CASTLING_MASK = 3,
+    BLACK_OO_MASK = 4,
+    OO_MASK = 5,
+    BLACK_OOO_MASK = 8,
+    OOO_MASK = 10,
+    BLACK_CASTLING_MASK = 12,
+    ANY_CASTLING_MASK = 15,
+    CASTLING_MASK_NB = 16
+};
+
+INLINED bool clright_is_valid(CastlingRight clright) {
+    return clright < CASTLING_NB;
 }
 
-INLINED CastlingRights relative_cr(Color color)
-{
+INLINED CastlingRight relative_clright(Color color, bool queenside) {
     assert(color_is_valid(color));
-    return color == WHITE ? WHITE_CASTLING : BLACK_CASTLING;
+    return (color == WHITE ? WHITE_OO : BLACK_OO) + queenside;
+}
+
+INLINED CastlingMask clright_to_clmask(CastlingRight clright) {
+    assert(clright_is_valid(clright));
+    return (CastlingMask)(1 << clright);
+}
+
+INLINED bool clmask_is_valid(CastlingMask clmask) {
+    return clmask < CASTLING_MASK_NB;
+}
+
+INLINED CastlingMask relative_clmask(Color color) {
+    assert(color_is_valid(color));
+    return color == WHITE ? WHITE_CASTLING_MASK : BLACK_CASTLING_MASK;
+}
+
+INLINED CastlingRight clmask_to_clright(CastlingMask clmask) {
+    assert(clmask != 0 && !(clmask & (clmask - 1)) && clmask_is_valid(clmask));
+    return (CastlingRight)u64_first_one(clmask);
 }
 
 // API for the move type.

--- a/src/include/hashkey.h
+++ b/src/include/hashkey.h
@@ -49,7 +49,7 @@ extern Key ZobristPsq[PIECE_NB][SQUARE_NB];
 extern Key ZobristEnPassant[FILE_NB];
 
 // Global table for Zobrist castling hashes
-extern Key ZobristCastling[CASTLING_NB];
+extern Key ZobristCastling[CASTLING_MASK_NB];
 
 // Global value for Zobrist STM hash
 extern Key ZobristSideToMove;

--- a/src/sources/evaluate.c
+++ b/src/sources/evaluate.c
@@ -503,7 +503,7 @@ static Scorepair
 
             // Check if the King resides between the Rook and the middle of the board.
             if (king_file != rook_file && (king_file < rook_file) == (king_file >= FILE_E)) {
-                const bool can_castle = !!(board->stack->castlings & relative_cr(us));
+                const bool can_castle = !!(board->stack->castlings & relative_clmask(us));
                 ret += can_castle ? RookTrapped : RookBuried;
                 trace_add(can_castle ? IDX_ROOK_TRAPPED : IDX_ROOK_BURIED, us, 1);
             }

--- a/src/sources/hashkey.c
+++ b/src/sources/hashkey.c
@@ -23,7 +23,7 @@
 
 Key ZobristPsq[PIECE_NB][SQUARE_NB];
 Key ZobristEnPassant[FILE_NB];
-Key ZobristCastling[CASTLING_NB];
+Key ZobristCastling[CASTLING_MASK_NB];
 Key ZobristSideToMove;
 
 void zobrist_init(void) {
@@ -39,7 +39,7 @@ void zobrist_init(void) {
         ZobristEnPassant[file] = u64_random(&seed);
     }
 
-    for (CastlingRights cr = 0; cr < CASTLING_NB; ++cr) {
+    for (CastlingMask cr = 0; cr < CASTLING_MASK_NB; ++cr) {
         ZobristCastling[cr] = 0;
         u64 b = cr;
 

--- a/src/sources/movelist.c
+++ b/src/sources/movelist.c
@@ -363,14 +363,16 @@ ExtendedMove *
         movelist = extmove_generate_piece_moves(movelist, board, us, piecetype, target_squares);
     }
 
-    CastlingRights kingside = us == WHITE ? WHITE_OO : BLACK_OO;
-    CastlingRights queenside = us == WHITE ? WHITE_OOO : BLACK_OOO;
+    CastlingRight kingside = relative_clright(us, false);
+    CastlingRight queenside = relative_clright(us, true);
 
-    if ((board->stack->castlings & kingside) && !board_castling_is_blocked(board, kingside)) {
+    if ((board->stack->castlings & clright_to_clmask(kingside))
+        && !board_castling_is_blocked(board, kingside)) {
         (movelist++)->move = create_castling_move(our_king, board->castling_rook_square[kingside]);
     }
 
-    if ((board->stack->castlings & queenside) && !board_castling_is_blocked(board, queenside)) {
+    if ((board->stack->castlings & clright_to_clmask(queenside))
+        && !board_castling_is_blocked(board, queenside)) {
         (movelist++)->move = create_castling_move(our_king, board->castling_rook_square[queenside]);
     }
 
@@ -439,14 +441,16 @@ ExtendedMove *extmove_generate_quiet(ExtendedMove *restrict movelist, const Boar
         movelist = extmove_generate_piece_moves(movelist, board, us, piecetype, empty_squares);
     }
 
-    CastlingRights kingside = us == WHITE ? WHITE_OO : BLACK_OO;
-    CastlingRights queenside = us == WHITE ? WHITE_OOO : BLACK_OOO;
+    CastlingRight kingside = relative_clright(us, false);
+    CastlingRight queenside = relative_clright(us, true);
 
-    if ((board->stack->castlings & kingside) && !board_castling_is_blocked(board, kingside)) {
+    if ((board->stack->castlings & clright_to_clmask(kingside))
+        && !board_castling_is_blocked(board, kingside)) {
         (movelist++)->move = create_castling_move(our_king, board->castling_rook_square[kingside]);
     }
 
-    if ((board->stack->castlings & queenside) && !board_castling_is_blocked(board, queenside)) {
+    if ((board->stack->castlings & clright_to_clmask(queenside))
+        && !board_castling_is_blocked(board, queenside)) {
         (movelist++)->move = create_castling_move(our_king, board->castling_rook_square[queenside]);
     }
 

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v37.1"
+#define UCI_VERSION "v37.2"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
Strip 108 bytes off of the board struct, by indexing rook squares and paths for castling rights by the index of the corresponding castling instead of its mask, reducing the size of both arrays from 16 to 4.

Passed non-regression STC:
```
Elo   | 3.60 +- 3.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 8014 W: 2059 L: 1976 D: 3979
Penta | [49, 701, 2433, 766, 58]
```
http://chess.grantnet.us/test/39117/

Bench: 4,646,465