### PR TITLE
Add minor piece correction history

### DIFF
--- a/src/include/board.h
+++ b/src/include/board.h
@@ -31,6 +31,7 @@ typedef struct Boardstack {
     Key king_pawn_key;
     Key material_key;
     Key nonpawn_key[COLOR_NB];
+    Key minor_key;
     Bitboard checkers;
     Bitboard king_blockers[COLOR_NB];
     Bitboard pinners[COLOR_NB];
@@ -240,6 +241,11 @@ INLINED Key board_pawn_key(const Board *board) {
 
 INLINED Key board_nonpawn_key(const Board *board, Color color) {
     return board->stack->nonpawn_key[color];
+}
+
+INLINED Key board_minor_key(const Board *board) {
+    return board->stack->minor_key ^ ZobristPsq[WHITE_KING][board_king_square(board, WHITE)]
+        ^ ZobristPsq[BLACK_KING][board_king_square(board, BLACK)];
 }
 
 // Helper function for grabbing a material count with standardized values: Pawn=1, Knight=Bishop=3,

--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -75,6 +75,7 @@ typedef struct {
     CaptureHistory *capture_hist;
     CorrectionHistory *pawn_corrhist;
     CorrectionHistory *nonpawn_corrhist;
+    CorrectionHistory *minor_corrhist;
     KingPawnTable *king_pawn_table;
 
     u16 seldepth;

--- a/src/sources/board.c
+++ b/src/sources/board.c
@@ -126,6 +126,7 @@ static void boardstack_set_check_info(Boardstack *restrict stack, const Board *r
 void boardstack_init(Boardstack *restrict stack, const Board *restrict board) {
     stack->board_key = stack->king_pawn_key = stack->material_key = 0;
     stack->nonpawn_key[WHITE] = stack->nonpawn_key[BLACK] = 0;
+    stack->minor_key = 0;
     stack->material[WHITE] = stack->material[BLACK] = 0;
     stack->checkers = board_attackers_to(board, board_king_square(board, board->side_to_move))
         & board_color_bb(board, color_flip(board->side_to_move));
@@ -145,6 +146,9 @@ void boardstack_init(Boardstack *restrict stack, const Board *restrict board) {
         } else {
             stack->material[piece_color(piece)] += PieceScores[MIDGAME][piece];
             stack->nonpawn_key[piece_color(piece)] ^= ZobristPsq[piece][square];
+            if (piece_type(piece) == KNIGHT || piece_type(piece) == BISHOP) {
+                stack->minor_key ^= ZobristPsq[piece][square];
+            }
         }
     }
 
@@ -1025,6 +1029,7 @@ void board_do_move_gc(
     new_stack->material_key = board->stack->material_key;
     new_stack->nonpawn_key[WHITE] = board->stack->nonpawn_key[WHITE];
     new_stack->nonpawn_key[BLACK] = board->stack->nonpawn_key[BLACK];
+    new_stack->minor_key = board->stack->minor_key;
     new_stack->material[WHITE] = board->stack->material[WHITE];
     new_stack->material[BLACK] = board->stack->material[BLACK];
 
@@ -1061,6 +1066,9 @@ void board_do_move_gc(
         } else {
             new_stack->material[them] -= PieceScores[MIDGAME][captured_piece];
             new_stack->nonpawn_key[them] ^= ZobristPsq[captured_piece][capture_square];
+            if (piece_type(captured_piece) == KNIGHT || piece_type(captured_piece) == BISHOP) {
+                new_stack->minor_key ^= ZobristPsq[captured_piece][capture_square];
+            }
         }
 
         board_remove_piece(board, capture_square);
@@ -1121,6 +1129,9 @@ void board_do_move_gc(
         new_stack->king_pawn_key ^= ZobristPsq[piece][from] ^ ZobristPsq[piece][to];
     } else {
         new_stack->nonpawn_key[us] ^= ZobristPsq[piece][from] ^ ZobristPsq[piece][to];
+        if (piece_type(piece) == KNIGHT || piece_type(piece) == BISHOP) {
+            new_stack->minor_key ^= ZobristPsq[piece][from] ^ ZobristPsq[piece][to];
+        }
     }
 
     new_stack->captured_piece = captured_piece;

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -603,7 +603,10 @@ Score search(
                                     board_nonpawn_key(board, WHITE))
             + correction_hist_score(&worker->nonpawn_corrhist[BLACK],
                                     board->side_to_move,
-                                    board_nonpawn_key(board, BLACK));
+                                    board_nonpawn_key(board, BLACK))
+            + correction_hist_score(worker->minor_corrhist,
+                                    board->side_to_move,
+                                    board_minor_key(board));
 
         // Save the eval in TT so that other workers won't have to recompute it.
         tt_save(&worker->pool->tt, tt_entry, key, NO_SCORE, raw_eval, 0, NO_BOUND, NO_MOVE);
@@ -1057,6 +1060,13 @@ main_loop:
             i16_min(16, depth + 1),
             (i32)best_score - (i32)ss->static_eval
         );
+        correction_hist_update(
+            worker->minor_corrhist,
+            board->side_to_move,
+            board_minor_key(board),
+            i16_min(16, depth + 1),
+            (i32)best_score - (i32)ss->static_eval
+        );
     }
 
     // Only save TT for the first MultiPV move in root nodes.
@@ -1159,6 +1169,11 @@ Score qsearch(bool pv_node, Board *board, Score alpha, Score beta, Searchstack *
                                     &worker->nonpawn_corrhist[BLACK],
                                     board->side_to_move,
                                     board_nonpawn_key(board, BLACK)
+                )
+                + correction_hist_score(
+                                    worker->minor_corrhist,
+                                    board->side_to_move,
+                                    board_minor_key(board)
                 );
 
             // Try to use the TT score as a better evaluation of the position.
@@ -1184,6 +1199,11 @@ Score qsearch(bool pv_node, Board *board, Score alpha, Score beta, Searchstack *
                                     &worker->nonpawn_corrhist[BLACK],
                                     board->side_to_move,
                                     board_nonpawn_key(board, BLACK)
+                )
+                + correction_hist_score(
+                                    worker->minor_corrhist,
+                                    board->side_to_move,
+                                    board_minor_key(board)
                 );
         }
 

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v37.5"
+#define UCI_VERSION "v37.6"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},

--- a/src/sources/worker.c
+++ b/src/sources/worker.c
@@ -93,6 +93,7 @@ void worker_init(Worker *worker, usize thread_index, struct WorkerPool *pool) {
     worker->capture_hist = wrap_aligned_alloc(64, sizeof(CaptureHistory));
     worker->pawn_corrhist = wrap_aligned_alloc(64, sizeof(CorrectionHistory));
     worker->nonpawn_corrhist = wrap_aligned_alloc(64, sizeof(CorrectionHistory) * COLOR_NB);
+    worker->minor_corrhist = wrap_aligned_alloc(64, sizeof(CorrectionHistory));
     worker->king_pawn_table = wrap_aligned_alloc(64, sizeof(KingPawnTable));
     worker->root_moves = wrap_malloc(sizeof(RootMove) * MAX_MOVES);
     worker->must_exit = false;
@@ -137,6 +138,7 @@ void worker_destroy(Worker *worker) {
     wrap_aligned_free(worker->capture_hist);
     wrap_aligned_free(worker->pawn_corrhist);
     wrap_aligned_free(worker->nonpawn_corrhist);
+    wrap_aligned_free(worker->minor_corrhist);
     wrap_aligned_free(worker->king_pawn_table);
     free(worker->root_moves);
 }
@@ -148,6 +150,7 @@ void worker_init_new_game(Worker *worker) {
     memset(worker->capture_hist, 0, sizeof(CaptureHistory));
     memset(worker->pawn_corrhist, 0, sizeof(CorrectionHistory));
     memset(worker->nonpawn_corrhist, 0, sizeof(CorrectionHistory) * COLOR_NB);
+    memset(worker->minor_corrhist, 0, sizeof(CorrectionHistory));
     memset(worker->king_pawn_table, 0, sizeof(KingPawnTable));
 }
 


### PR DESCRIPTION
Correction history indexed by kings, bishops, and knights

Passed STC
```
Elo   | 3.07 +- 2.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 29978 W: 8316 L: 8051 D: 13611
Penta | [576, 3441, 6762, 3562, 648]
```
http://chess.grantnet.us/test/39737/

Passed LTC
```
Elo   | 4.45 +- 3.30 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12406 W: 3027 L: 2868 D: 6511
Penta | [60, 1450, 3057, 1543, 93]
```
http://chess.grantnet.us/test/39743/

Bench: 4,144,459