### PR TITLE
Fix minor corrhist

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -584,7 +584,10 @@ Score search(
                                     board_nonpawn_key(board, WHITE))
             + correction_hist_score(&worker->nonpawn_corrhist[BLACK],
                                     board->side_to_move,
-                                    board_nonpawn_key(board, BLACK));
+                                    board_nonpawn_key(board, BLACK))
+            + correction_hist_score(worker->minor_corrhist,
+                                    board->side_to_move,
+                                    board_minor_key(board));
 
         // Try to use the TT score as a better evaluation of the position.
         if (tt_bound & (tt_score > eval ? LOWER_BOUND : UPPER_BOUND)) {

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v37.6"
+#define UCI_VERSION "v37.7"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
Passed STC Nonregression
```
Elo   | 1.52 +- 3.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 17658 W: 4500 L: 4423 D: 8735
Penta | [251, 2107, 4011, 2234, 226]
```
http://chess.grantnet.us/test/39762/

Bench: 4,682,754