### PR TITLE
Change the formula for noisy SEE pruning to a linear one

### DIFF
--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -818,7 +818,7 @@ main_loop:
                 && !board_see_above(
                     board,
                     currmove,
-                    (is_quiet ? -48 * depth : -23 * depth * depth)
+                    (is_quiet ? -48 * depth : -60 * depth)
                 )) {
                 continue;
             }

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v37.8"
+#define UCI_VERSION "v37.9"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
Passed STC:

```
Elo   | 3.08 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 26814 W: 6934 L: 6696 D: 13184
Penta | [360, 3216, 6032, 3424, 375]
```
http://chess.grantnet.us/test/39764/

Passed LTC:

```
Elo   | 4.74 +- 3.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11286 W: 2710 L: 2556 D: 6020
Penta | [57, 1303, 2793, 1409, 81]
```
http://chess.grantnet.us/test/39772/

Bench: 4,470,010