### PR TITLE
Add major piece correction history

### DIFF
--- a/src/include/board.h
+++ b/src/include/board.h
@@ -32,6 +32,7 @@ typedef struct Boardstack {
     Key material_key;
     Key nonpawn_key[COLOR_NB];
     Key minor_key;
+    Key major_key;
     Bitboard checkers;
     Bitboard king_blockers[COLOR_NB];
     Bitboard pinners[COLOR_NB];
@@ -245,6 +246,11 @@ INLINED Key board_nonpawn_key(const Board *board, Color color) {
 
 INLINED Key board_minor_key(const Board *board) {
     return board->stack->minor_key ^ ZobristPsq[WHITE_KING][board_king_square(board, WHITE)]
+        ^ ZobristPsq[BLACK_KING][board_king_square(board, BLACK)];
+}
+
+INLINED Key board_major_key(const Board *board) {
+    return board->stack->major_key ^ ZobristPsq[WHITE_KING][board_king_square(board, WHITE)]
         ^ ZobristPsq[BLACK_KING][board_king_square(board, BLACK)];
 }
 

--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -76,6 +76,7 @@ typedef struct {
     CorrectionHistory *pawn_corrhist;
     CorrectionHistory *nonpawn_corrhist;
     CorrectionHistory *minor_corrhist;
+    CorrectionHistory *major_corrhist;
     KingPawnTable *king_pawn_table;
 
     u16 seldepth;

--- a/src/sources/board.c
+++ b/src/sources/board.c
@@ -150,7 +150,7 @@ void boardstack_init(Boardstack *restrict stack, const Board *restrict board) {
             if (piece_type(piece) == KNIGHT || piece_type(piece) == BISHOP) {
                 stack->minor_key ^= ZobristPsq[piece][square];
             }
-            if (piece_type(piece) == ROOK || piece_type(piece) == KING) {
+            if (piece_type(piece) == ROOK || piece_type(piece) == QUEEN) {
                 stack->major_key ^= ZobristPsq[piece][square];
             }
         }

--- a/src/sources/board.c
+++ b/src/sources/board.c
@@ -127,6 +127,7 @@ void boardstack_init(Boardstack *restrict stack, const Board *restrict board) {
     stack->board_key = stack->king_pawn_key = stack->material_key = 0;
     stack->nonpawn_key[WHITE] = stack->nonpawn_key[BLACK] = 0;
     stack->minor_key = 0;
+    stack->major_key = 0;
     stack->material[WHITE] = stack->material[BLACK] = 0;
     stack->checkers = board_attackers_to(board, board_king_square(board, board->side_to_move))
         & board_color_bb(board, color_flip(board->side_to_move));
@@ -148,6 +149,9 @@ void boardstack_init(Boardstack *restrict stack, const Board *restrict board) {
             stack->nonpawn_key[piece_color(piece)] ^= ZobristPsq[piece][square];
             if (piece_type(piece) == KNIGHT || piece_type(piece) == BISHOP) {
                 stack->minor_key ^= ZobristPsq[piece][square];
+            }
+            if (piece_type(piece) == ROOK || piece_type(piece) == KING) {
+                stack->major_key ^= ZobristPsq[piece][square];
             }
         }
     }
@@ -1030,6 +1034,7 @@ void board_do_move_gc(
     new_stack->nonpawn_key[WHITE] = board->stack->nonpawn_key[WHITE];
     new_stack->nonpawn_key[BLACK] = board->stack->nonpawn_key[BLACK];
     new_stack->minor_key = board->stack->minor_key;
+    new_stack->major_key = board->stack->major_key;
     new_stack->material[WHITE] = board->stack->material[WHITE];
     new_stack->material[BLACK] = board->stack->material[BLACK];
 
@@ -1049,6 +1054,8 @@ void board_do_move_gc(
         key ^= ZobristPsq[captured_piece][rook_to];
         new_stack->nonpawn_key[us] ^= ZobristPsq[captured_piece][rook_from];
         new_stack->nonpawn_key[us] ^= ZobristPsq[captured_piece][rook_to];
+        new_stack->major_key ^= ZobristPsq[captured_piece][rook_from];
+        new_stack->major_key ^= ZobristPsq[captured_piece][rook_to];
 
         captured_piece = NO_PIECE;
     }
@@ -1068,6 +1075,9 @@ void board_do_move_gc(
             new_stack->nonpawn_key[them] ^= ZobristPsq[captured_piece][capture_square];
             if (piece_type(captured_piece) == KNIGHT || piece_type(captured_piece) == BISHOP) {
                 new_stack->minor_key ^= ZobristPsq[captured_piece][capture_square];
+            }
+            if (piece_type(captured_piece) == ROOK || piece_type(captured_piece) == QUEEN) {
+                new_stack->major_key ^= ZobristPsq[captured_piece][capture_square];
             }
         }
 
@@ -1131,6 +1141,9 @@ void board_do_move_gc(
         new_stack->nonpawn_key[us] ^= ZobristPsq[piece][from] ^ ZobristPsq[piece][to];
         if (piece_type(piece) == KNIGHT || piece_type(piece) == BISHOP) {
             new_stack->minor_key ^= ZobristPsq[piece][from] ^ ZobristPsq[piece][to];
+        }
+        if (piece_type(piece) == ROOK || piece_type(piece) == QUEEN) {
+            new_stack->major_key ^= ZobristPsq[piece][from] ^ ZobristPsq[piece][to];
         }
     }
 

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -587,7 +587,10 @@ Score search(
                                     board_nonpawn_key(board, BLACK))
             + correction_hist_score(worker->minor_corrhist,
                                     board->side_to_move,
-                                    board_minor_key(board));
+                                    board_minor_key(board))
+            + correction_hist_score(worker->major_corrhist,
+                                    board->side_to_move,
+                                    board_major_key(board));
 
         // Try to use the TT score as a better evaluation of the position.
         if (tt_bound & (tt_score > eval ? LOWER_BOUND : UPPER_BOUND)) {
@@ -609,7 +612,10 @@ Score search(
                                     board_nonpawn_key(board, BLACK))
             + correction_hist_score(worker->minor_corrhist,
                                     board->side_to_move,
-                                    board_minor_key(board));
+                                    board_minor_key(board))
+            + correction_hist_score(worker->major_corrhist,
+                                    board->side_to_move,
+                                    board_major_key(board));
 
         // Save the eval in TT so that other workers won't have to recompute it.
         tt_save(&worker->pool->tt, tt_entry, key, NO_SCORE, raw_eval, 0, NO_BOUND, NO_MOVE);
@@ -1070,6 +1076,13 @@ main_loop:
             i16_min(16, depth + 1),
             (i32)best_score - (i32)ss->static_eval
         );
+        correction_hist_update(
+            worker->major_corrhist,
+            board->side_to_move,
+            board_major_key(board),
+            i16_min(16, depth + 1),
+            (i32)best_score - (i32)ss->static_eval
+        );
     }
 
     // Only save TT for the first MultiPV move in root nodes.
@@ -1177,6 +1190,11 @@ Score qsearch(bool pv_node, Board *board, Score alpha, Score beta, Searchstack *
                                     worker->minor_corrhist,
                                     board->side_to_move,
                                     board_minor_key(board)
+                )
+                + correction_hist_score(
+                                    worker->major_corrhist,
+                                    board->side_to_move,
+                                    board_major_key(board)
                 );
 
             // Try to use the TT score as a better evaluation of the position.
@@ -1207,6 +1225,11 @@ Score qsearch(bool pv_node, Board *board, Score alpha, Score beta, Searchstack *
                                     worker->minor_corrhist,
                                     board->side_to_move,
                                     board_minor_key(board)
+                )
+                + correction_hist_score(
+                                    worker->major_corrhist,
+                                    board->side_to_move,
+                                    board_major_key(board)
                 );
         }
 

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v37.9"
+#define UCI_VERSION "v37.10"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},

--- a/src/sources/worker.c
+++ b/src/sources/worker.c
@@ -94,6 +94,7 @@ void worker_init(Worker *worker, usize thread_index, struct WorkerPool *pool) {
     worker->pawn_corrhist = wrap_aligned_alloc(64, sizeof(CorrectionHistory));
     worker->nonpawn_corrhist = wrap_aligned_alloc(64, sizeof(CorrectionHistory) * COLOR_NB);
     worker->minor_corrhist = wrap_aligned_alloc(64, sizeof(CorrectionHistory));
+    worker->major_corrhist = wrap_aligned_alloc(64, sizeof(CorrectionHistory));
     worker->king_pawn_table = wrap_aligned_alloc(64, sizeof(KingPawnTable));
     worker->root_moves = wrap_malloc(sizeof(RootMove) * MAX_MOVES);
     worker->must_exit = false;
@@ -139,6 +140,7 @@ void worker_destroy(Worker *worker) {
     wrap_aligned_free(worker->pawn_corrhist);
     wrap_aligned_free(worker->nonpawn_corrhist);
     wrap_aligned_free(worker->minor_corrhist);
+    wrap_aligned_free(worker->major_corrhist);
     wrap_aligned_free(worker->king_pawn_table);
     free(worker->root_moves);
 }
@@ -151,6 +153,7 @@ void worker_init_new_game(Worker *worker) {
     memset(worker->pawn_corrhist, 0, sizeof(CorrectionHistory));
     memset(worker->nonpawn_corrhist, 0, sizeof(CorrectionHistory) * COLOR_NB);
     memset(worker->minor_corrhist, 0, sizeof(CorrectionHistory));
+    memset(worker->major_corrhist, 0, sizeof(CorrectionHistory));
     memset(worker->king_pawn_table, 0, sizeof(KingPawnTable));
 }
 


### PR DESCRIPTION
Correction history indexed by kings, queens, and rooks

Passed STC
```
Elo   | 3.82 +- 2.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18756 W: 4865 L: 4659 D: 9232
Penta | [229, 2257, 4266, 2331, 295]
```
http://chess.grantnet.us/test/39769/

Passed LTC
```
Elo   | 2.22 +- 1.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 43416 W: 10366 L: 10089 D: 22961
Penta | [253, 5051, 10830, 5314, 260]
```
http://chess.grantnet.us/test/39773/

Bench: TBA