### PR TITLE
Add an option to enable node management

### DIFF
--- a/src/include/search_params.h
+++ b/src/include/search_params.h
@@ -28,6 +28,7 @@ typedef struct {
     i64 multi_pv;
     bool show_wdl;
     bool normalize_score;
+    bool tm_for_nodes;
 
     Duration wtime;
     Duration btime;
@@ -52,7 +53,8 @@ void search_params_init(
     i64 move_overhead,
     i64 multi_pv,
     bool show_wdl,
-    bool normalize_score
+    bool normalize_score,
+    bool tm_for_nodes
 );
 
 // Sets the search params according to the given UCI command

--- a/src/include/timeman.h
+++ b/src/include/timeman.h
@@ -36,6 +36,7 @@ typedef struct {
     Timepoint start;
     TimemanMode mode;
     bool pondering;
+    bool node_clock;
     u64 delay_check_nodes;
 
     Duration average_time;

--- a/src/include/uci.h
+++ b/src/include/uci.h
@@ -34,6 +34,7 @@ typedef struct {
     bool ponder;
     bool show_wdl;
     bool normalize_score;
+    bool tm_for_nodes;
 } OptionValues;
 
 typedef struct {

--- a/src/include/worker.h
+++ b/src/include/worker.h
@@ -194,6 +194,6 @@ void wpool_check_time(WorkerPool *wpool);
 
 // These functions can be called from any thread.
 
-u64 wpool_get_total_nodes(WorkerPool *wpool);
+u64 wpool_get_total_nodes(const WorkerPool *wpool);
 
 #endif

--- a/src/sources/evaluate.c
+++ b/src/sources/evaluate.c
@@ -870,7 +870,10 @@ static Score eval_scale_endgame(const Board *board, const KingPawnEntry *kpe, Sc
     }
     // Rook endgames: drawish if the pawn advantage is small, and all strong side pawns are on the
     // same side of the board. Don't scale if the defending King is far from his own pawns.
-    else if (strong_material == ROOK_MG_SCORE && weak_material == ROOK_MG_SCORE && (bb_popcount(strong_pawns) < 2 + bb_popcount(weak_pawns)) && !!(KINGSIDE_BB & strong_pawns) != !!(QUEENSIDE_BB & strong_pawns) && !!(king_attacks_bb(board_king_square(board, weak_side)) & weak_pawns)) {
+    else if (strong_material == ROOK_MG_SCORE && weak_material == ROOK_MG_SCORE
+             && (bb_popcount(strong_pawns) < 2 + bb_popcount(weak_pawns))
+             && !!(KINGSIDE_BB & strong_pawns) != !!(QUEENSIDE_BB & strong_pawns)
+             && !!(king_attacks_bb(board_king_square(board, weak_side)) & weak_pawns)) {
         factor = 130;
     }
     // Check if we have a specialized function for the given material distribution.

--- a/src/sources/search.c
+++ b/src/sources/search.c
@@ -821,11 +821,7 @@ main_loop:
             // SEE Pruning. For low-depth nodes, don't search moves which seem to lose too much
             // material to be interesting.
             if (depth <= 12
-                && !board_see_above(
-                    board,
-                    currmove,
-                    (is_quiet ? -48 * depth : -60 * depth)
-                )) {
+                && !board_see_above(board, currmove, (is_quiet ? -48 * depth : -60 * depth))) {
                 continue;
             }
         }

--- a/src/sources/search_params.c
+++ b/src/sources/search_params.c
@@ -28,13 +28,15 @@ void search_params_init(
     i64 move_overhead,
     i64 multi_pv,
     bool show_wdl,
-    bool normalize_score
+    bool normalize_score,
+    bool tm_for_nodes
 ) {
     *search_params = (SearchParams) {
         .move_overhead = move_overhead,
         .multi_pv = multi_pv,
         .show_wdl = show_wdl,
         .normalize_score = normalize_score,
+        .tm_for_nodes = tm_for_nodes,
 
         .wtime = 0,
         .btime = 0,
@@ -289,6 +291,7 @@ void search_params_set_from_uci(
                 UINT64_MAX,
                 STATIC_STRVIEW("nodes")
             )) {
+            search_params->tc_is_set |= search_params->tm_for_nodes;
             continue;
         }
 

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v37.10"
+#define UCI_VERSION "v37.11"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},
@@ -67,6 +67,7 @@ static void uci_init_options(Uci *uci) {
         .ponder = false,
         .show_wdl = false,
         .normalize_score = true,
+        .tm_for_nodes = false,
     };
 
     optlist_init(&uci->option_list);
@@ -128,6 +129,13 @@ static void uci_init_options(Uci *uci) {
         &uci->option_list,
         strview_from_cstr("NormalizeScore"),
         &uci->option_values.normalize_score,
+        NULL,
+        NULL
+    );
+    optlist_add_check(
+        &uci->option_list,
+        strview_from_cstr("TimemanForNodes"),
+        &uci->option_values.tm_for_nodes,
         NULL,
         NULL
     );
@@ -214,7 +222,8 @@ void uci_go(Uci *uci, StringView args) {
         uci->option_values.move_overhead,
         uci->option_values.multi_pv,
         uci->option_values.show_wdl,
-        uci->option_values.normalize_score
+        uci->option_values.normalize_score,
+        uci->option_values.tm_for_nodes
     );
     search_params_set_from_uci(&search_params, &uci->root_board, args);
     wpool_start_search(&uci->worker_pool, &uci->root_board, &search_params);

--- a/src/sources/worker.c
+++ b/src/sources/worker.c
@@ -358,13 +358,14 @@ void wpool_check_time(WorkerPool *wpool) {
         return;
     }
 
-    if (wpool_get_total_nodes(wpool) >= wpool->search_params.nodes
+    if ((!wpool->search_params.tm_for_nodes
+         && wpool_get_total_nodes(wpool) >= wpool->search_params.nodes)
         || timeman_must_stop_search(&wpool->timeman, wpool, timepoint_now())) {
         wpool_stop(wpool);
     }
 }
 
-u64 wpool_get_total_nodes(WorkerPool *wpool) {
+u64 wpool_get_total_nodes(const WorkerPool *wpool) {
     u64 total = 0;
 
     for (usize i = 0; i < wpool->worker_count; ++i) {


### PR DESCRIPTION
The TimemanForNodes option allows the engine to use a flexible node limit when using 'go nodes' as it does for standard time controls. This should allow datagen games to be of a much higher quality without needing higher npm values, or instead keep the same game quality with faster games.

A short test against master at fixed nodes confirms this:

```
--------------------------------------------------
Results of node-manager vs master (16000 nodes, 1t, 1MB, UHO_4060_v2.epd):
Elo: 108.68 +/- 18.95, nElo: 131.86 +/- 21.53
LOS: 100.00 %, DrawRatio: 30.60 %, PairsRatio: 3.45
Games: 1000, Wins: 522, Losses: 219, Draws: 259, Points: 651.5 (65.15 %)
Ptnml(0-2): [23, 55, 153, 134, 135], WL/DD Ratio: 3.37
--------------------------------------------------
```

(node-manager was using slightly more nodes than master on average, 17072 vs 16051. The 25x scaling constant can be fine-tuned later to address this.)

Bench: 3,811,876