### PR TITLE
Fix uninitialized variable in timeman_init function

### DIFF
--- a/src/sources/timeman.c
+++ b/src/sources/timeman.c
@@ -38,6 +38,7 @@ void timeman_init(
     timeman->start = start;
     timeman->pondering = false;
     timeman->delay_check_nodes = 1000;
+    timeman->node_clock = false;
 
     if (search_params->nodes != 0) {
         timeman->delay_check_nodes = (u64)fmin(1000.0, sqrt(search_params->nodes) + 0.5);

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v37.20"
+#define UCI_VERSION "v37.21"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
Always set node_clock to false as a default value so that it gets initialized on non-tournament-like time limits.

Bench: 4,400,041