### PR TITLE
Fix incorrect material validation on board_try_init

### DIFF
--- a/src/sources/board.c
+++ b/src/sources/board.c
@@ -317,7 +317,7 @@ static bool board_has_invalid_material(const Board *board, Color color) {
     const u8 pknights = u8_max(2, knights) - 2;
     const u8 pbishops = u8_max(2, bishops) - 2;
     const u8 prooks = u8_max(2, rooks) - 2;
-    const u8 pqueens = u8_max(2, queens) - 2;
+    const u8 pqueens = u8_max(1, queens) - 1;
     const u8 promoted = pknights + pbishops + prooks + pqueens;
 
     pawns += promoted;

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v37.21"
+#define UCI_VERSION "v37.22"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
Fix the incorrect count for promoted queens which was off by one, allowing positions with 10 queens to pass through material validation in FEN parsing.

Bench: 4,400,041