### PR TITLE
Fix incorrect implementation of mem_segm_index()

### DIFF
--- a/src/sources/memory.c
+++ b/src/sources/memory.c
@@ -79,6 +79,8 @@ usize mem_segm_index(const u8 *data, usize size, const u8 *segm, usize segmsize)
             break;
         }
 
+        next += i;
+
         if (mem_equal(data + next, segm, segmsize)) {
             return next;
         }

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -25,7 +25,7 @@
 #include "wdl.h"
 #include "wmalloc.h"
 
-#define UCI_VERSION "v37.22"
+#define UCI_VERSION "v37.23"
 
 static const Command UciCommands[] = {
     {STATIC_STRVIEW("bench"), uci_bench},


### PR DESCRIPTION
The `next` variable was missing the offset of previous scanning iterations when getting multiple matches for the first byte of the searched string, which would cause infinite loops when entering UCI commands like `position fen m m 12345`.

Bench: 4,400,041